### PR TITLE
feat: add ledger connector

### DIFF
--- a/.changeset/cool-beds-pump.md
+++ b/.changeset/cool-beds-pump.md
@@ -1,0 +1,5 @@
+---
+'@wagmi/connectors': minor
+---
+
+Added Ledger connector

--- a/.changeset/cool-beds-pump.md
+++ b/.changeset/cool-beds-pump.md
@@ -2,4 +2,4 @@
 '@wagmi/connectors': minor
 ---
 
-Added Ledger connector
+Added `LedgerConnector`

--- a/packages/connectors/README.md
+++ b/packages/connectors/README.md
@@ -47,12 +47,12 @@ const client = createClient({
 
 ## Connectors
 
-- [`InjectedConnector`](/packages/connectors/src/injected.ts)
 - [`CoinbaseWalletConnector`](/packages/connectors/src/coinbaseWallet.ts)
+- [`InjectedConnector`](/packages/connectors/src/injected.ts)
+- [`LedgerConnector`](/packages/connectors/src/ledger.ts)
 - [`MetaMaskConnector`](/packages/connectors/src/metaMask.ts)
 - [`MockConnector`](/packages/connectors/src/mock.ts)
 - [`WalletConnectConnector`](/packages/connectors/src/walletConnect.ts)
-- [`LedgerConnector`](/packages/connectors/src/ledger.ts)
 
 ## Contributing
 

--- a/packages/connectors/README.md
+++ b/packages/connectors/README.md
@@ -52,6 +52,7 @@ const client = createClient({
 - [`MetaMaskConnector`](/packages/connectors/src/metaMask.ts)
 - [`MockConnector`](/packages/connectors/src/mock.ts)
 - [`WalletConnectConnector`](/packages/connectors/src/walletConnect.ts)
+- [`LedgerConnector`](/packages/connectors/src/ledger.ts)
 
 ## Contributing
 

--- a/packages/connectors/ledger/package.json
+++ b/packages/connectors/ledger/package.json
@@ -1,0 +1,4 @@
+{
+  "type": "module",
+  "main": "../dist/ledger.js"
+}

--- a/packages/connectors/ledger/package.json
+++ b/packages/connectors/ledger/package.json
@@ -1,4 +1,4 @@
 {
-  "type": "module",
-  "main": "../dist/ledger.js"
+  "main": "../dist/ledger.js",
+  "type": "module"
 }

--- a/packages/connectors/package.json
+++ b/packages/connectors/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@coinbase/wallet-sdk": "^3.5.4",
     "@walletconnect/ethereum-provider": "^1.8.0",
+    "@ledgerhq/connect-kit-loader": "^1.0.0",
     "abitype": "^0.1.8",
     "eventemitter3": "^4.0.7"
   },
@@ -53,6 +54,10 @@
     "./walletConnect": {
       "types": "./dist/walletConnect.d.ts",
       "default": "./dist/walletConnect.js"
+    },
+    "./ledger": {
+      "types": "./dist/ledger.d.ts",
+      "default": "./dist/ledger.js"
     }
   },
   "files": [
@@ -61,7 +66,8 @@
     "/injected",
     "/metaMask",
     "/mock",
-    "/walletConnect"
+    "/walletConnect",
+    "/ledger"
   ],
   "sideEffects": false,
   "contributors": [

--- a/packages/connectors/package.json
+++ b/packages/connectors/package.json
@@ -43,6 +43,10 @@
       "types": "./dist/injected.d.ts",
       "default": "./dist/injected.js"
     },
+    "./ledger": {
+      "types": "./dist/ledger.d.ts",
+      "default": "./dist/ledger.js"
+    },
     "./metaMask": {
       "types": "./dist/metaMask.d.ts",
       "default": "./dist/metaMask.js"
@@ -54,10 +58,6 @@
     "./walletConnect": {
       "types": "./dist/walletConnect.d.ts",
       "default": "./dist/walletConnect.js"
-    },
-    "./ledger": {
-      "types": "./dist/ledger.d.ts",
-      "default": "./dist/ledger.js"
     }
   },
   "files": [

--- a/packages/connectors/src/ledger.test.ts
+++ b/packages/connectors/src/ledger.test.ts
@@ -1,0 +1,5 @@
+import { describe, it } from 'vitest'
+
+describe('LedgerConnector', () => {
+  it.todo('inits')
+})

--- a/packages/connectors/src/ledger.ts
+++ b/packages/connectors/src/ledger.ts
@@ -1,0 +1,187 @@
+import {
+  SupportedProviders,
+  loadConnectKit,
+} from '@ledgerhq/connect-kit-loader'
+import type {
+  EthereumProvider,
+  LedgerConnectKit,
+} from '@ledgerhq/connect-kit-loader'
+import {
+  Chain,
+  ProviderRpcError,
+  RpcError,
+  UserRejectedRequestError,
+  normalizeChainId,
+} from '@wagmi/core'
+import { providers } from 'ethers'
+import { getAddress } from 'ethers/lib/utils.js'
+
+import type { ConnectorData } from './base'
+import { Connector } from './base'
+
+type LedgerConnectorOptions = {
+  chainId?: number
+  bridge?: string
+  infuraId?: string
+  rpc?: { [chainId: number]: string }
+
+  enableDebugLogs?: boolean
+}
+
+type LedgerSigner = providers.JsonRpcSigner
+
+export class LedgerConnector extends Connector<
+  EthereumProvider,
+  LedgerConnectorOptions,
+  LedgerSigner
+> {
+  readonly id = 'ledger'
+  readonly name = 'Ledger'
+  readonly ready = true
+
+  private connectKitPromise: Promise<LedgerConnectKit>
+  private provider?: EthereumProvider
+
+  constructor({
+    chains,
+    options = { enableDebugLogs: false },
+  }: {
+    chains?: Chain[]
+    options?: LedgerConnectorOptions
+  } = {}) {
+    super({ chains, options })
+
+    this.connectKitPromise = loadConnectKit()
+  }
+
+  async connect(): Promise<Required<ConnectorData>> {
+    try {
+      const connectKit = await this.connectKitPromise
+
+      if (this.options.enableDebugLogs) {
+        connectKit.enableDebugLogs()
+      }
+
+      connectKit.checkSupport({
+        providerType: SupportedProviders.Ethereum,
+        chainId: this.options.chainId,
+        infuraId: this.options.infuraId,
+        rpc: this.options.rpc,
+      })
+
+      const provider = await this.getProvider({ forceCreate: true })
+
+      if (provider.on) {
+        provider.on('accountsChanged', this.onAccountsChanged)
+        provider.on('chainChanged', this.onChainChanged)
+        provider.on('disconnect', this.onDisconnect)
+      }
+
+      this.emit('message', { type: 'connecting' })
+
+      const account = await this.getAccount()
+      const id = await this.getChainId()
+      const unsupported = this.isChainUnsupported(id)
+
+      return {
+        account,
+        chain: { id, unsupported },
+        provider: new providers.Web3Provider(
+          provider as providers.ExternalProvider,
+        ),
+      }
+    } catch (error) {
+      if ((error as ProviderRpcError).code === 4001) {
+        throw new UserRejectedRequestError(error)
+      }
+      if ((error as RpcError).code === -32002) {
+        throw error instanceof Error ? error : new Error(String(error))
+      }
+
+      throw error
+    }
+  }
+
+  async disconnect() {
+    const provider = await this.getProvider()
+
+    if (provider?.disconnect) {
+      await provider.disconnect()
+    }
+
+    if (provider?.removeListener) {
+      provider.removeListener('accountsChanged', this.onAccountsChanged)
+      provider.removeListener('chainChanged', this.onChainChanged)
+      provider.removeListener('disconnect', this.onDisconnect)
+    }
+  }
+
+  async getAccount() {
+    const provider = await this.getProvider()
+    const accounts = (await provider.request({
+      method: 'eth_requestAccounts',
+    })) as string[]
+    const account = getAddress(accounts[0] as string)
+
+    return account
+  }
+
+  async getChainId() {
+    const provider = await this.getProvider()
+    const chainId = (await provider.request({
+      method: 'eth_chainId',
+    })) as number
+
+    return normalizeChainId(chainId)
+  }
+
+  async getProvider(
+    { forceCreate }: { chainId?: number; forceCreate?: boolean } = {
+      forceCreate: false,
+    },
+  ) {
+    if (!this.provider || forceCreate) {
+      const connectKit = await this.connectKitPromise
+      this.provider = (await connectKit.getProvider()) as EthereumProvider
+    }
+    return this.provider
+  }
+
+  async getSigner() {
+    const [provider, account] = await Promise.all([
+      this.getProvider(),
+      this.getAccount(),
+    ])
+    return new providers.Web3Provider(
+      provider as providers.ExternalProvider,
+    ).getSigner(account)
+  }
+
+  async isAuthorized() {
+    try {
+      const provider = await this.getProvider()
+      const accounts = (await provider.request({
+        method: 'eth_accounts',
+      })) as string[]
+      const account = accounts[0]
+      return !!account
+    } catch {
+      return false
+    }
+  }
+
+  protected onAccountsChanged = (accounts: string[]) => {
+    if (accounts.length === 0) this.emit('disconnect')
+    else this.emit('change', { account: getAddress(accounts[0] as string) })
+  }
+
+  protected onChainChanged = (chainId: number | string) => {
+    const id = normalizeChainId(chainId)
+    const unsupported = this.isChainUnsupported(id)
+    this.emit('change', { chain: { id, unsupported } })
+  }
+
+  protected onDisconnect = () => {
+    this.emit('disconnect')
+  }
+}

--- a/packages/connectors/tsup.config.ts
+++ b/packages/connectors/tsup.config.ts
@@ -12,6 +12,7 @@ export default defineConfig(
       'src/metaMask.ts',
       'src/mock/index.ts',
       'src/walletConnect.ts',
+      'src/ledger.ts',
     ],
     platform: 'browser',
   }),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,7 @@ importers:
   packages/connectors:
     specifiers:
       '@coinbase/wallet-sdk': ^3.5.4
+      '@ledgerhq/connect-kit-loader': ^1.0.0
       '@wagmi/core': ^0.8.0
       '@walletconnect/ethereum-provider': ^1.8.0
       abitype: ^0.1.8
@@ -61,6 +62,7 @@ importers:
       eventemitter3: ^4.0.7
     dependencies:
       '@coinbase/wallet-sdk': 3.6.2
+      '@ledgerhq/connect-kit-loader': 1.0.0
       '@walletconnect/ethereum-provider': 1.8.0
       abitype: 0.1.8
       eventemitter3: 4.0.7
@@ -784,6 +786,10 @@ packages:
     dependencies:
       '@json-rpc-tools/types': 1.7.6
       '@pedrouid/environment': 1.0.1
+
+  /@ledgerhq/connect-kit-loader/1.0.0:
+    resolution: {integrity: sha512-TQnVSwg8WKUx5WUQtGKJurFpnpeaVHmJfKdElVMBgccfHska6+4XA+554NjHQ46GvI/V0wknFShnudTRqc5JXg==}
+    dev: false
 
   /@manypkg/find-root/1.1.0:
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}


### PR DESCRIPTION
## Description

Adds a Ledger connector that makes use of the [Ledger Connect Kit](https://developers.ledger.com/docs/connect/introduction/) to either show the Ledger Connect extension on Safari if installed, guide the user to install it if supported, or allow them to directly connect to Ledger Live through Wallet Connect on other platforms.

Let me know if there are any other changes needed. It seems that the docs and playground will be kept on the main wagmi repo but they reference the connectors.

This PR is based on #3, so the changes will be reduced after that one is merged.

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/references/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)
