### PR TITLE
chore: update `bscTestnet` RPC URL

### DIFF
--- a/.changeset/red-eels-poke.md
+++ b/.changeset/red-eels-poke.md
@@ -1,0 +1,5 @@
+---
+'@wagmi/chains': patch
+---
+
+Updated `bscTestnet` RPC URL

--- a/packages/chains/src/bscTestnet.ts
+++ b/packages/chains/src/bscTestnet.ts
@@ -10,7 +10,7 @@ export const bscTestnet: Chain = {
     symbol: 'tBNB',
   },
   rpcUrls: {
-    default: { http: ['https://bsctestapi.terminet.io/rpc'] },
+    default: { http: ['https://bsc-testnet.public.blastapi.io'] },
   },
   blockExplorers: {
     etherscan: { name: 'BscScan', url: 'https://testnet.bscscan.com' },


### PR DESCRIPTION
Fixes https://github.com/wagmi-dev/wagmi/issues/1488

## Description

Looks like the current RPC URL has CORS issues – switching to another.

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/references/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: jxom.eth
