### PR TITLE
Update default RPC and block explorer urls for Arbitrum Goerli

### DIFF
--- a/.changeset/eighty-ghosts-watch.md
+++ b/.changeset/eighty-ghosts-watch.md
@@ -1,0 +1,5 @@
+---
+'@wagmi/chains': patch
+---
+
+update arbitrum goerli default rpc and block explorer

--- a/packages/chains/src/arbitrumGoerli.ts
+++ b/packages/chains/src/arbitrumGoerli.ts
@@ -19,17 +19,17 @@ export const arbitrumGoerli: Chain = {
       webSocket: ['wss://arbitrum-goerli.infura.io/ws/v3'],
     },
     default: {
-      http: ['https://arb1.arbitrum.io/rpc'],
+      http: ['https://goerli-rollup.arbitrum.io/rpc'],
     },
   },
   blockExplorers: {
-    etherscan: { name: 'Arbiscan', url: 'https://arbiscan.io' },
-    default: { name: 'Arbiscan', url: 'https://arbiscan.io' },
+    etherscan: { name: 'Arbiscan', url: 'https://goerli.arbiscan.io/' },
+    default: { name: 'Arbiscan', url: 'https://goerli.arbiscan.io/' },
   },
   contracts: {
     multicall3: {
       address: '0xca11bde05977b3631167028862be2a173976ca11',
-      blockCreated: 7654707,
+      blockCreated: 88114,
     },
   },
   testnet: true,


### PR DESCRIPTION
## Description

This PR fixes Arbitrum Goerli default rpc and block explorer. It was pointing to Arbitrum One. 

https://chainlist.org/chain/421613

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/references/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)
