### PR TITLE
fix: retrieve selected account after requesting permissions

### DIFF
--- a/.changeset/nervous-mails-drum.md
+++ b/.changeset/nervous-mails-drum.md
@@ -1,0 +1,5 @@
+---
+'@wagmi/connectors': patch
+---
+
+Fixed issue where connecting to MetaMask may return with a stale address

--- a/packages/connectors/src/metaMask.ts
+++ b/packages/connectors/src/metaMask.ts
@@ -97,6 +97,7 @@ export class MetaMaskConnector extends InjectedConnector {
               method: 'wallet_requestPermissions',
               params: [{ eth_accounts: {} }],
             })
+            // User may have selected a different account so we will need to revalidate here.
             account = await this.getAccount()
           } catch (error) {
             // Not all MetaMask injected providers support `wallet_requestPermissions` (e.g. MetaMask iOS).

--- a/packages/connectors/src/metaMask.ts
+++ b/packages/connectors/src/metaMask.ts
@@ -97,6 +97,7 @@ export class MetaMaskConnector extends InjectedConnector {
               method: 'wallet_requestPermissions',
               params: [{ eth_accounts: {} }],
             })
+            account = await this.getAccount()
           } catch (error) {
             // Not all MetaMask injected providers support `wallet_requestPermissions` (e.g. MetaMask iOS).
             // Only bubble up error if user rejects request


### PR DESCRIPTION
Fixes [#1530](https://github.com/wagmi-dev/wagmi/issues/1530)

## Description

Fixing an issue where connecting to MetaMask may return with a stale address

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/references/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: jxom.eth
