### PR TITLE
bug: remove spolia ENS address that does not exist

### DIFF
--- a/.changeset/tiny-pillows-punch.md
+++ b/.changeset/tiny-pillows-punch.md
@@ -1,0 +1,5 @@
+---
+'@wagmi/chains': patch
+---
+
+Remove ENS registry for sepolia which does not current exist

--- a/packages/chains/src/sepolia.ts
+++ b/packages/chains/src/sepolia.ts
@@ -25,9 +25,6 @@ export const sepolia: Chain = {
     },
   },
   contracts: {
-    ensRegistry: {
-      address: '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e',
-    },
     multicall3: {
       address: '0xca11bde05977b3631167028862be2a173976ca11',
       blockCreated: 6507670,


### PR DESCRIPTION
## Description

Can't speak for when the ENS team may deploy a working ENS for sepolia. I have one at 0xbc4693cb0f572b99f6ab4462602b5a0b8585010b which I use but it is not affiliated with the core ENS team in any way.

In conjunction w/ [this PR](https://github.com/wagmi-dev/wagmi/pull/1539)-- removes the ens registry definition for sepolia. One can see at https://sepolia.etherscan.io/address/0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e that it does not exist at this time.

If the above PR goes in, then this config will get passed to providers. The downside appears to be that an exception will be shown in the console. While the error appears to be non-destructive it also does not appear if this address is removed.

This can always be added back when ENS team deploys to sepolia, or simply ignored. I only offer it up to eliminate a console error if the other PR goes through.

![image](https://user-images.githubusercontent.com/97764360/208789262-3d570ea5-0bf4-49b9-8d2e-9e75ac31d66b.png)

```
next-dev.js?36dd:20 TypeError: Cannot read properties of null (reading 'getAvatar')
    at FallbackProvider.eval (webpack-internal:///../../node_modules/@ethersproject/providers/lib.esm/base-provider.js:1922:43)
    at Generator.next (<anonymous>)
    at fulfilled (webpack-internal:///../../node_modules/@ethersproject/providers/lib.esm/base-provider.js:28:58)
```

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/references/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address:
