### PR TITLE
feat: add `switchSigner` to `MockProvider`

### DIFF
--- a/.changeset/lazy-garlics-protect.md
+++ b/.changeset/lazy-garlics-protect.md
@@ -1,0 +1,5 @@
+---
+'@wagmi/connectors': patch
+---
+
+Add `switchSigner` method to `MockProvider`.

--- a/packages/connectors/src/mock/provider.ts
+++ b/packages/connectors/src/mock/provider.ts
@@ -67,6 +67,12 @@ export class MockProvider extends providers.BaseProvider {
     this.events.emit('chainChanged', chainId)
   }
 
+  async switchSigner(signer: Signer) {
+    const address = await signer.getAddress()
+    this.#signer = signer
+    this.events.emit('accountsChanged', [address])
+  }
+
   async watchAsset(_asset: {
     address: string
     decimals?: number


### PR DESCRIPTION
## Description

Adding a `switchSigner` method to `MockProvider` so consumers can test account changes (e.g. https://github.com/wagmi-dev/wagmi/pull/1623) via the mock Connector.

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/references/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: jxom.eth
