### PR TITLE
Add new web3modal, Reuse active websocket  connection for sign v2

### DIFF
--- a/.changeset/twenty-eels-explode.md
+++ b/.changeset/twenty-eels-explode.md
@@ -1,0 +1,5 @@
+---
+'@wagmi/connectors': minor
+---
+
+Improved handling for universal-provider, replace legacy qrcodemodal with new web3modal

--- a/.changeset/twenty-eels-explode.md
+++ b/.changeset/twenty-eels-explode.md
@@ -1,5 +1,5 @@
 ---
-'@wagmi/connectors': minor
+'@wagmi/connectors': patch
 ---
 
-Improved handling for universal-provider, replace legacy qrcodemodal with new web3modal
+Replaced legacy qrcodemodal with web3modal for WalletConnect v2.

--- a/packages/connectors/package.json
+++ b/packages/connectors/package.json
@@ -20,8 +20,8 @@
     "@coinbase/wallet-sdk": "^3.5.4",
     "@ledgerhq/connect-kit-loader": "^1.0.1",
     "@walletconnect/ethereum-provider": "^1.8.0",
-    "@web3modal/standalone": "2.0.0-rc.2",
-    "@walletconnect/universal-provider": "2.2.0-82965d54",
+    "@web3modal/standalone": "^2.0.0-rc.2",
+    "@walletconnect/universal-provider": "^2.2.1",
     "abitype": "^0.1.8",
     "eventemitter3": "^4.0.7"
   },

--- a/packages/connectors/package.json
+++ b/packages/connectors/package.json
@@ -20,7 +20,7 @@
     "@coinbase/wallet-sdk": "^3.5.4",
     "@ledgerhq/connect-kit-loader": "^1.0.1",
     "@walletconnect/ethereum-provider": "^1.8.0",
-    "@walletconnect/qrcode-modal": "^1.8.0",
+    "@web3modal/standalone": "2.0.0-rc.2",
     "@walletconnect/universal-provider": "^2.2.0",
     "abitype": "^0.1.8",
     "eventemitter3": "^4.0.7"

--- a/packages/connectors/package.json
+++ b/packages/connectors/package.json
@@ -21,7 +21,7 @@
     "@ledgerhq/connect-kit-loader": "^1.0.1",
     "@walletconnect/ethereum-provider": "^1.8.0",
     "@web3modal/standalone": "2.0.0-rc.2",
-    "@walletconnect/universal-provider": "^2.2.0",
+    "@walletconnect/universal-provider": "2.2.0-82965d54",
     "abitype": "^0.1.8",
     "eventemitter3": "^4.0.7"
   },

--- a/packages/connectors/src/walletConnect.ts
+++ b/packages/connectors/src/walletConnect.ts
@@ -79,10 +79,9 @@ export class WalletConnectConnector extends Connector<
 
   async #createWeb3Modal() {
     const { Web3Modal } = await import('@web3modal/standalone')
-    const { version } = this.options
-    const projectId = version === '2' ? this.options.projectId : undefined
+    const { projectId } = this.options
     this.web3Modal = new Web3Modal({
-      projectId,
+      projectId: this.version === '2' ? projectId : undefined,
       standaloneChains: this.namespacedChains,
     })
   }

--- a/packages/connectors/src/walletConnect.ts
+++ b/packages/connectors/src/walletConnect.ts
@@ -58,7 +58,7 @@ export class WalletConnectConnector extends Connector<
   readonly id = 'walletConnect'
   readonly name = 'WalletConnect'
   readonly ready = true
-  private web3Modal?: Web3Modal = undefined
+  #web3Modal?: Web3Modal
 
   #provider?: WalletConnectProvider | UniversalProvider
 

--- a/packages/connectors/src/walletConnect.ts
+++ b/packages/connectors/src/walletConnect.ts
@@ -314,7 +314,6 @@ export class WalletConnectConnector extends Connector<
       ).default
       this.#provider = new WalletConnectProvider({
         ...this.options,
-        qrcode: false,
         chainId,
         rpc: { ...rpc, ...this.options?.rpc },
       })

--- a/packages/connectors/src/walletConnect.ts
+++ b/packages/connectors/src/walletConnect.ts
@@ -141,13 +141,12 @@ export class WalletConnectConnector extends Connector<
               },
             }),
             ...(this.options.qrcode
-              ? // When using WalletConnect QR Code Modal, open modal and listen for close callback.
-                // If modal is closed, reject promise so `catch` block for `connect` is called.
-                [
+              ? [
                   new Promise<void>((_resolve, reject) =>
                     provider.on('display_uri', async (uri: string) => {
                       if (!this.#web3Modal) await this.#createWeb3Modal()
                       await this.#web3Modal?.openModal({ uri })
+                      // Modal is closed, reject promise so `catch` block for `connect` is called.
                       this.#web3Modal?.subscribeModal(({ open }) => {
                         if (!open) reject(new Error('user rejected'))
                       })

--- a/packages/connectors/src/walletConnect.ts
+++ b/packages/connectors/src/walletConnect.ts
@@ -58,7 +58,6 @@ export class WalletConnectConnector extends Connector<
   readonly id = 'walletConnect'
   readonly name = 'WalletConnect'
   readonly ready = true
-  private providerInitialized = false
   private web3Modal?: Web3Modal = undefined
 
   #provider?: WalletConnectProvider | UniversalProvider
@@ -102,7 +101,7 @@ export class WalletConnectConnector extends Connector<
 
       const provider = await this.getProvider({
         chainId: targetChainId,
-        create: isV2 && this.providerInitialized ? false : true,
+        create: isV2 && !this.#provider ? false : true,
       })
       provider.on('accountsChanged', this.onAccountsChanged)
       provider.on('chainChanged', this.onChainChanged)
@@ -293,7 +292,6 @@ export class WalletConnectConnector extends Connector<
         this.#provider = await WalletConnectProvider.init(
           this.options as UniversalProviderOpts,
         )
-        this.providerInitialized = true
         if (chainId)
           this.#provider.setDefaultChain(
             `${defaultV2Config.namespace}:${chainId}`,

--- a/packages/connectors/src/walletConnect.ts
+++ b/packages/connectors/src/walletConnect.ts
@@ -11,6 +11,7 @@ import type {
   UniversalProviderOpts,
   UniversalProvider as UniversalProvider_,
 } from '@walletconnect/universal-provider'
+import type { Web3Modal } from '@web3modal/standalone'
 import { providers } from 'ethers'
 import { getAddress, hexValue } from 'ethers/lib/utils.js'
 
@@ -57,6 +58,8 @@ export class WalletConnectConnector extends Connector<
   readonly id = 'walletConnect'
   readonly name = 'WalletConnect'
   readonly ready = true
+  private providerInitialized = false
+  private web3Modal?: Web3Modal = undefined
 
   #provider?: WalletConnectProvider | UniversalProvider
 
@@ -69,7 +72,26 @@ export class WalletConnectConnector extends Connector<
     return '1'
   }
 
+  get namespacedChains() {
+    return this.chains.map(
+      (chain) => `${defaultV2Config.namespace}:${chain.id}`,
+    )
+  }
+
+  private async createWeb3Modal() {
+    const { Web3Modal } = await import('@web3modal/standalone')
+    const { version } = this.options
+    const projectId = version === '2' ? this.options.projectId : undefined
+    this.web3Modal = new Web3Modal({
+      projectId,
+      standaloneChains: this.namespacedChains,
+    })
+  }
+
   async connect({ chainId }: { chainId?: number } = {}) {
+    const isV2 = this.version === '2'
+    const isV1 = this.version === '1'
+
     try {
       let targetChainId = chainId
       if (!targetChainId) {
@@ -80,13 +102,13 @@ export class WalletConnectConnector extends Connector<
 
       const provider = await this.getProvider({
         chainId: targetChainId,
-        create: true,
+        create: isV2 && this.providerInitialized ? false : true,
       })
       provider.on('accountsChanged', this.onAccountsChanged)
       provider.on('chainChanged', this.onChainChanged)
       provider.on('disconnect', this.onDisconnect)
 
-      if (this.version === '2') {
+      if (isV2) {
         provider.on('session_delete', this.onDisconnect)
         provider.on('display_uri', this.onDisplayUri)
 
@@ -109,9 +131,7 @@ export class WalletConnectConnector extends Connector<
                 [defaultV2Config.namespace]: {
                   methods: defaultV2Config.methods,
                   events: defaultV2Config.events,
-                  chains: this.chains.map(
-                    (chain) => `${defaultV2Config.namespace}:${chain.id}`,
-                  ),
+                  chains: this.namespacedChains,
                   rpcMap: this.chains.reduce(
                     (rpc, chain) => ({
                       ...rpc,
@@ -126,22 +146,21 @@ export class WalletConnectConnector extends Connector<
               ? // When using WalletConnect QR Code Modal, open modal and listen for close callback.
                 // If modal is closed, reject promise so `catch` block for `connect` is called.
                 [
-                  new Promise((_res, reject) =>
-                    provider.on('display_uri', async (uri: string) =>
-                      (
-                        await import('@walletconnect/qrcode-modal')
-                      ).default.open(uri, () =>
-                        reject(new Error('user rejected')),
-                      ),
-                    ),
+                  new Promise<void>((_resolve, reject) =>
+                    provider.on('display_uri', async (uri: string) => {
+                      if (!this.web3Modal) await this.createWeb3Modal()
+                      await this.web3Modal?.openModal({ uri })
+                      this.web3Modal?.subscribeModal(({ open }) => {
+                        if (!open) reject(new Error('user rejected'))
+                      })
+                    }),
                   ),
                 ]
               : []),
           ])
 
           // If execution reaches here, connection was successful and we can close modal.
-          if (this.options.qrcode)
-            (await import('@walletconnect/qrcode-modal')).default.close()
+          if (this.options.qrcode) this.web3Modal?.closeModal()
         }
       }
 
@@ -151,7 +170,7 @@ export class WalletConnectConnector extends Connector<
       const accounts = (await Promise.race([
         provider.enable(),
         // When using WalletConnect v1 QR Code Modal, handle user rejection request from wallet
-        ...(this.version === '1' && this.options.qrcode
+        ...(isV1 && this.options.qrcode
           ? [
               new Promise((_res, reject) =>
                 (provider as WalletConnectProvider).connector.on(
@@ -168,7 +187,7 @@ export class WalletConnectConnector extends Connector<
 
       // Not all WalletConnect v1 options support programmatic chain switching.
       // Only enable for wallet options that do.
-      if (this.version === '1') {
+      if (isV1) {
         const walletName =
           (provider as WalletConnectProvider).connector?.peerMeta?.name ?? ''
 
@@ -197,8 +216,7 @@ export class WalletConnectConnector extends Connector<
         ),
       }
     } catch (error) {
-      if (this.version === '2' && this.options.qrcode)
-        (await import('@walletconnect/qrcode-modal')).default.close()
+      if (isV2 && this.options.qrcode) this.web3Modal?.closeModal()
       // WalletConnect v1: "user closed modal"
       // WalletConnect v2: "user rejected"
       if (
@@ -275,6 +293,7 @@ export class WalletConnectConnector extends Connector<
         this.#provider = await WalletConnectProvider.init(
           this.options as UniversalProviderOpts,
         )
+        this.providerInitialized = true
         if (chainId)
           this.#provider.setDefaultChain(
             `${defaultV2Config.namespace}:${chainId}`,

--- a/packages/connectors/src/walletConnect.ts
+++ b/packages/connectors/src/walletConnect.ts
@@ -101,7 +101,7 @@ export class WalletConnectConnector extends Connector<
 
       const provider = await this.getProvider({
         chainId: targetChainId,
-        create: isV2 && !this.#provider ? false : true,
+        create: isV2 && this.#provider ? false : true,
       })
       provider.on('accountsChanged', this.onAccountsChanged)
       provider.on('chainChanged', this.onChainChanged)

--- a/packages/connectors/src/walletConnect.ts
+++ b/packages/connectors/src/walletConnect.ts
@@ -77,7 +77,7 @@ export class WalletConnectConnector extends Connector<
     )
   }
 
-  private async createWeb3Modal() {
+  async #createWeb3Modal() {
     const { Web3Modal } = await import('@web3modal/standalone')
     const { version } = this.options
     const projectId = version === '2' ? this.options.projectId : undefined

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,8 +71,8 @@ importers:
       '@ledgerhq/connect-kit-loader': ^1.0.1
       '@wagmi/core': ^0.8.0
       '@walletconnect/ethereum-provider': ^1.8.0
-      '@walletconnect/universal-provider': ^2.2.0
-      '@web3modal/standalone': 2.0.0-rc.2
+      '@walletconnect/universal-provider': ^2.2.1
+      '@web3modal/standalone': ^2.0.0-rc.2
       abitype: ^0.1.8
       ethers: ^5.7.2
       eventemitter3: ^4.0.7
@@ -80,7 +80,7 @@ importers:
       '@coinbase/wallet-sdk': 3.6.2
       '@ledgerhq/connect-kit-loader': 1.0.1
       '@walletconnect/ethereum-provider': 1.8.0
-      '@walletconnect/universal-provider': 2.2.0
+      '@walletconnect/universal-provider': 2.2.1
       '@web3modal/standalone': 2.0.0-rc.2
       abitype: 0.1.8
       eventemitter3: 4.0.7
@@ -1604,8 +1604,8 @@ packages:
       - bufferutil
       - utf-8-validate
 
-  /@walletconnect/core/2.2.0:
-    resolution: {integrity: sha512-oucu/Ro1bYL9DQIRqB4Y5HUfOFRhl/sOMyQ3SVLtq9J6jrFs5uePiw13dvhz7+p1BzWVWV5Jw2+elmJllNiB/A==}
+  /@walletconnect/core/2.2.1:
+    resolution: {integrity: sha512-UoXohoIavMxj2iUOcnixY8uGl0sibJdGU6UX9zkke2Wgc2UKsvtkFZ/ZU3YG1XrIPWSpZ94lkhkNGstuRKz0wQ==}
     dependencies:
       '@walletconnect/heartbeat': 1.0.1
       '@walletconnect/jsonrpc-provider': 1.0.6
@@ -1617,8 +1617,8 @@ packages:
       '@walletconnect/relay-auth': 1.0.4
       '@walletconnect/safe-json': 1.0.1
       '@walletconnect/time': 1.0.2
-      '@walletconnect/types': 2.2.0
-      '@walletconnect/utils': 2.2.0
+      '@walletconnect/types': 2.2.1
+      '@walletconnect/utils': 2.2.1
       events: 3.3.0
       lodash.isequal: 4.5.0
       pino: 7.11.0
@@ -1804,18 +1804,18 @@ packages:
     dependencies:
       tslib: 1.14.1
 
-  /@walletconnect/sign-client/2.2.0:
-    resolution: {integrity: sha512-7oEYp/t/uuR85/meMqJvaJBxVY/R9CR6xJOxL4sobOioL2Dy58m1HkxpODqxSpdZvJ1sCm6x7zYlqOWYbY1kdA==}
+  /@walletconnect/sign-client/2.2.1:
+    resolution: {integrity: sha512-oABkkYPU8tlN42U8ht3Um7bzwrRiUb2S74Y0rWjc3xfs76g6MLO5Ja4ER1jAhCcECs9tFf84wdNwLLhT77JoSg==}
     dependencies:
-      '@walletconnect/core': 2.2.0
+      '@walletconnect/core': 2.2.1
       '@walletconnect/events': 1.0.1
       '@walletconnect/heartbeat': 1.0.1
       '@walletconnect/jsonrpc-provider': 1.0.6
       '@walletconnect/jsonrpc-utils': 1.0.4
       '@walletconnect/logger': 2.0.1
       '@walletconnect/time': 1.0.2
-      '@walletconnect/types': 2.2.0
-      '@walletconnect/utils': 2.2.0
+      '@walletconnect/types': 2.2.1
+      '@walletconnect/utils': 2.2.1
       events: 3.3.0
       pino: 7.11.0
     transitivePeerDependencies:
@@ -1857,8 +1857,8 @@ packages:
   /@walletconnect/types/1.8.0:
     resolution: {integrity: sha512-Cn+3I0V0vT9ghMuzh1KzZvCkiAxTq+1TR2eSqw5E5AVWfmCtECFkVZBP6uUJZ8YjwLqXheI+rnjqPy7sVM4Fyg==}
 
-  /@walletconnect/types/2.2.0:
-    resolution: {integrity: sha512-mxxXcHTtRaa3FiLWWEYEOA3wyGzOc9Fdv2Objms/COcPAropAY/8A0kceqCDB0si1UFOl6KpEzvm5WHJpJi9tQ==}
+  /@walletconnect/types/2.2.1:
+    resolution: {integrity: sha512-97Ko6u6jC/B/7ymI2ddc+Hdn4x47Pkv0Y7IYHU0RD/J9878S5pJ2nQjDfWhvfDp1GWKgzHVDy6VHwaxDiLtkSw==}
     dependencies:
       '@walletconnect/events': 1.0.1
       '@walletconnect/heartbeat': 1.0.1
@@ -1871,17 +1871,17 @@ packages:
       - lokijs
     dev: false
 
-  /@walletconnect/universal-provider/2.2.0:
-    resolution: {integrity: sha512-FJhk8YRbvLWRbVlwmI5LDzdPRZNpNfZ52BeCV8jcQYkxlZzZ/QtToxp3oYaYXECI2isQ3mvEwadC6qzzua7B1A==}
+  /@walletconnect/universal-provider/2.2.1:
+    resolution: {integrity: sha512-6I4JxAZ5rC+UQCqsVjMlZ/EmYP7z16J7Kixqh1Iw7Ro7SnSfFeahUr80sctGs2vR7XF1ADzVyxmreJBriXdXDg==}
     dependencies:
       '@walletconnect/jsonrpc-http-connection': 1.0.4
       '@walletconnect/jsonrpc-provider': 1.0.6
       '@walletconnect/jsonrpc-types': 1.0.2
       '@walletconnect/jsonrpc-utils': 1.0.4
       '@walletconnect/logger': 2.0.1
-      '@walletconnect/sign-client': 2.2.0
-      '@walletconnect/types': 2.2.0
-      '@walletconnect/utils': 2.2.0
+      '@walletconnect/sign-client': 2.2.1
+      '@walletconnect/types': 2.2.1
+      '@walletconnect/utils': 2.2.1
       eip1193-provider: 1.0.1
       events: 3.3.0
       pino: 7.11.0
@@ -1905,8 +1905,8 @@ packages:
       js-sha3: 0.8.0
       query-string: 6.13.5
 
-  /@walletconnect/utils/2.2.0:
-    resolution: {integrity: sha512-nQqJHK3KMOKXSn277QhEVGQF5+LuP2PRZDDipl63Qz0ixz2okSpK7SGl1cfDm3728DVW1RxMi2qhmIiQwAU2tg==}
+  /@walletconnect/utils/2.2.1:
+    resolution: {integrity: sha512-DkjYcWMMBGznlyuenJkt1Z+IcPchhVbnYwMeQIZCu7gSbL9nUBsyzixfcWat5lapsBeGJDquhV63dU8pbkdhfg==}
     dependencies:
       '@stablelib/chacha20poly1305': 1.0.1
       '@stablelib/hkdf': 1.0.1
@@ -1917,7 +1917,7 @@ packages:
       '@walletconnect/relay-api': 1.0.7
       '@walletconnect/safe-json': 1.0.1
       '@walletconnect/time': 1.0.2
-      '@walletconnect/types': 2.2.0
+      '@walletconnect/types': 2.2.1
       '@walletconnect/window-getters': 1.0.1
       '@walletconnect/window-metadata': 1.0.1
       detect-browser: 5.3.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,8 +71,8 @@ importers:
       '@ledgerhq/connect-kit-loader': ^1.0.1
       '@wagmi/core': ^0.8.0
       '@walletconnect/ethereum-provider': ^1.8.0
-      '@walletconnect/qrcode-modal': ^1.8.0
       '@walletconnect/universal-provider': ^2.2.0
+      '@web3modal/standalone': 2.0.0-rc.2
       abitype: ^0.1.8
       ethers: ^5.7.2
       eventemitter3: ^4.0.7
@@ -80,8 +80,8 @@ importers:
       '@coinbase/wallet-sdk': 3.6.2
       '@ledgerhq/connect-kit-loader': 1.0.1
       '@walletconnect/ethereum-provider': 1.8.0
-      '@walletconnect/qrcode-modal': 1.8.0
       '@walletconnect/universal-provider': 2.2.0
+      '@web3modal/standalone': 2.0.0-rc.2
       abitype: 0.1.8
       eventemitter3: 4.0.7
     devDependencies:
@@ -1007,6 +1007,10 @@ packages:
     resolution: {integrity: sha512-OAJh9rMaypS1ttrSMwPznXqglJGcP3WPTTgz9YAKfkaMyUtZcHx7hCj4d6f7DdSVZOgWcyEYfZ8M2QrA2gtvgQ==}
     dev: false
 
+  /@lit/reactive-element/1.5.0:
+    resolution: {integrity: sha512-fQh9FDK0LPTwDk+0HhSZEtb8K0LTN1wXerwpGrWA+a8tWulYRDLI4vQDWp4GOIsewn0572KYV/oZ3+492D7osA==}
+    dev: false
+
   /@manypkg/find-root/1.1.0:
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
     dependencies:
@@ -1029,6 +1033,67 @@ packages:
 
   /@metamask/safe-event-emitter/2.0.0:
     resolution: {integrity: sha512-/kSXhY692qiV1MXu6EeOZvg5nECLclxNXcKCxJ3cXQgYuRymRHpdx/t7JXfsK+JLjwA1e1c1/SBrlQYpusC29Q==}
+
+  /@motionone/animation/10.15.1:
+    resolution: {integrity: sha512-mZcJxLjHor+bhcPuIFErMDNyrdb2vJur8lSfMCsuCB4UyV8ILZLvK+t+pg56erv8ud9xQGK/1OGPt10agPrCyQ==}
+    dependencies:
+      '@motionone/easing': 10.15.1
+      '@motionone/types': 10.15.1
+      '@motionone/utils': 10.15.1
+      tslib: 2.4.1
+    dev: false
+
+  /@motionone/dom/10.15.3:
+    resolution: {integrity: sha512-FQ7a2zMBXc1UeU8CG9G3yDpst55fbb0+C9A0VGfwOITitBCzigKZnXRgsRSWWR+FW57GSc13eGQxtYB0lKG0Ng==}
+    dependencies:
+      '@motionone/animation': 10.15.1
+      '@motionone/generators': 10.15.1
+      '@motionone/types': 10.15.1
+      '@motionone/utils': 10.15.1
+      hey-listen: 1.0.8
+      tslib: 2.4.1
+    dev: false
+
+  /@motionone/easing/10.15.1:
+    resolution: {integrity: sha512-6hIHBSV+ZVehf9dcKZLT7p5PEKHGhDwky2k8RKkmOvUoYP3S+dXsKupyZpqx5apjd9f+php4vXk4LuS+ADsrWw==}
+    dependencies:
+      '@motionone/utils': 10.15.1
+      tslib: 2.4.1
+    dev: false
+
+  /@motionone/generators/10.15.1:
+    resolution: {integrity: sha512-67HLsvHJbw6cIbLA/o+gsm7h+6D4Sn7AUrB/GPxvujse1cGZ38F5H7DzoH7PhX+sjvtDnt2IhFYF2Zp1QTMKWQ==}
+    dependencies:
+      '@motionone/types': 10.15.1
+      '@motionone/utils': 10.15.1
+      tslib: 2.4.1
+    dev: false
+
+  /@motionone/svelte/10.15.3:
+    resolution: {integrity: sha512-+wf2D/I6x7+d8byWPuSAGqYWCMWBc1Qq5uxGrw4WIZMc27qVtPirzbqMriILkJ4ry/FTftxBG8aQENsAYw10NA==}
+    dependencies:
+      '@motionone/dom': 10.15.3
+      tslib: 2.4.1
+    dev: false
+
+  /@motionone/types/10.15.1:
+    resolution: {integrity: sha512-iIUd/EgUsRZGrvW0jqdst8st7zKTzS9EsKkP+6c6n4MPZoQHwiHuVtTQLD6Kp0bsBLhNzKIBlHXponn/SDT4hA==}
+    dev: false
+
+  /@motionone/utils/10.15.1:
+    resolution: {integrity: sha512-p0YncgU+iklvYr/Dq4NobTRdAPv9PveRDUXabPEeOjBLSO/1FNB2phNTZxOxpi1/GZwYpAoECEa0Wam+nsmhSw==}
+    dependencies:
+      '@motionone/types': 10.15.1
+      hey-listen: 1.0.8
+      tslib: 2.4.1
+    dev: false
+
+  /@motionone/vue/10.15.3:
+    resolution: {integrity: sha512-+66Jy7Tx+phHnv2oYwX/TR4fiJRJ+PZnp8DstGyJYKEVeS2CIojnF8bJVnBS+6LuCZpzXjP3AG8lJ22rGVAovw==}
+    dependencies:
+      '@motionone/dom': 10.15.3
+      tslib: 2.4.1
+    dev: false
 
   /@mswjs/cookies/0.2.2:
     resolution: {integrity: sha512-mlN83YSrcFgk7Dm1Mys40DLssI1KdJji2CMKN8eOlBqsTADYzj2+jWzsANsUTFbxDMWPD5e9bfA1RGqBpS3O1g==}
@@ -1341,6 +1406,10 @@ packages:
     dependencies:
       '@types/node': 18.11.9
     dev: true
+
+  /@types/trusted-types/2.0.2:
+    resolution: {integrity: sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg==}
+    dev: false
 
   /@types/ws/7.4.7:
     resolution: {integrity: sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==}
@@ -1880,6 +1949,35 @@ packages:
       tslib: 1.14.1
     dev: false
 
+  /@web3modal/core/2.0.0-rc.2:
+    resolution: {integrity: sha512-a3J9r2p9o8rRQ8udsW1DAFg7ffiuEbWc70nZwGl5u9tA6KbucOYf5ROczzHqghjpuqpNdVLgtcA0+v4o9FEfwA==}
+    dependencies:
+      buffer: 6.0.3
+      valtio: 1.8.2
+    transitivePeerDependencies:
+      - react
+    dev: false
+
+  /@web3modal/standalone/2.0.0-rc.2:
+    resolution: {integrity: sha512-wiUugFqyLu2DIZMKT+A7164pVCQKSEYv/4p2PhegrN5fXV6aRjd6uogdF4VRw89u3i/7CJ295vzaOBCpJA4nIw==}
+    dependencies:
+      '@web3modal/core': 2.0.0-rc.2
+      '@web3modal/ui': 2.0.0-rc.2
+    transitivePeerDependencies:
+      - react
+    dev: false
+
+  /@web3modal/ui/2.0.0-rc.2:
+    resolution: {integrity: sha512-TrYcnZDyxhjflv9v1Q0yKjs0+TTZOrfIa66SIe2b+i1WoC+a9Gpk0r9tyIznxVi3bMLJDJifqLSSiLUWC4KOFQ==}
+    dependencies:
+      '@web3modal/core': 2.0.0-rc.2
+      lit: 2.5.0
+      motion: 10.15.3
+      qrcode: 1.5.1
+    transitivePeerDependencies:
+      - react
+    dev: false
+
   /@xmldom/xmldom/0.8.6:
     resolution: {integrity: sha512-uRjjusqpoqfmRkTaNuLJ2VohVr67Q5YwDATW3VU7PfzTj6IRaihGrYI7zckGZjxQPBIp63nfvJbM+Yu5ICh0Bg==}
     engines: {node: '>=10.0.0'}
@@ -1961,7 +2059,6 @@ packages:
   /ansi-regex/5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
-    dev: true
 
   /ansi-regex/6.0.1:
     resolution: {integrity: sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==}
@@ -1979,7 +2076,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       color-convert: 2.0.1
-    dev: true
 
   /ansi-styles/6.2.1:
     resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
@@ -2436,7 +2532,6 @@ packages:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 6.2.0
-    dev: true
 
   /cliui/8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
@@ -2470,14 +2565,12 @@ packages:
     engines: {node: '>=7.0.0'}
     dependencies:
       color-name: 1.1.4
-    dev: true
 
   /color-name/1.1.3:
     resolution: {integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==}
 
   /color-name/1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
-    dev: true
 
   /colorette/2.0.19:
     resolution: {integrity: sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==}
@@ -2748,11 +2841,14 @@ packages:
 
   /emoji-regex/8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
-    dev: true
 
   /emoji-regex/9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
     dev: true
+
+  /encode-utf8/1.0.3:
+    resolution: {integrity: sha512-ucAnuBEhUK4boH2HjVYG5Q2mQyPorvv0u/ocS+zhdw0S8AlHYY+GOFhP1Gio5z4icpP2ivFSvhtFjQi8+T9ppw==}
+    dev: false
 
   /end-of-stream/1.4.4:
     resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
@@ -3636,7 +3732,6 @@ packages:
     dependencies:
       locate-path: 5.0.0
       path-exists: 4.0.0
-    dev: true
 
   /find-up/5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
@@ -3899,6 +3994,10 @@ packages:
     resolution: {integrity: sha512-tWCK4biJ6hcLqTviLXVR9DTRfYGQMXEIUj3gwJ2rZ5wO/at3XtkI4g8mCvFdUF9l1KMBNCfmNAdnahm1cgavQA==}
     dev: true
 
+  /hey-listen/1.0.8:
+    resolution: {integrity: sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q==}
+    dev: false
+
   /hmac-drbg/1.0.1:
     resolution: {integrity: sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==}
     dependencies:
@@ -4064,7 +4163,6 @@ packages:
   /is-fullwidth-code-point/3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
-    dev: true
 
   /is-fullwidth-code-point/4.0.0:
     resolution: {integrity: sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==}
@@ -4085,7 +4183,7 @@ packages:
     dev: true
 
   /is-hex-prefixed/1.0.0:
-    resolution: {integrity: sha1-fY035q135dEnFIkTxXPggtd39VQ=}
+    resolution: {integrity: sha512-WvtOiug1VFrE9v1Cydwm+FnXd3+w9GaeVUss5W4v/SLy3UW00vP+6iNF2SdnfiBoLy4bTqVdkftNGTUeOFVsbA==}
     engines: {node: '>=6.5.0', npm: '>=3'}
 
   /is-interactive/1.0.0:
@@ -4411,6 +4509,27 @@ packages:
       wrap-ansi: 7.0.0
     dev: true
 
+  /lit-element/3.2.2:
+    resolution: {integrity: sha512-6ZgxBR9KNroqKb6+htkyBwD90XGRiqKDHVrW/Eh0EZ+l+iC+u+v+w3/BA5NGi4nizAVHGYvQBHUDuSmLjPp7NQ==}
+    dependencies:
+      '@lit/reactive-element': 1.5.0
+      lit-html: 2.5.0
+    dev: false
+
+  /lit-html/2.5.0:
+    resolution: {integrity: sha512-bLHosg1XL3JRUcKdSVI0sLCs0y1wWrj2sqqAN3cZ7bDDPNgmDHH29RV48x6Wz3ZmkxIupaE+z7uXSZ/pXWAO1g==}
+    dependencies:
+      '@types/trusted-types': 2.0.2
+    dev: false
+
+  /lit/2.5.0:
+    resolution: {integrity: sha512-DtnUP6vR3l4Q8nRPPNBD+UxbAhwJPeky+OVbi3pdgMqm0g57xFSl1Sj64D1rIB+nVNdiVVg8YxB0hqKjvdadZA==}
+    dependencies:
+      '@lit/reactive-element': 1.5.0
+      lit-element: 3.2.2
+      lit-html: 2.5.0
+    dev: false
+
   /load-tsconfig/0.2.3:
     resolution: {integrity: sha512-iyT2MXws+dc2Wi6o3grCFtGXpeMvHmJqS27sMPGtV2eUu4PeFnG+33I8BlFK1t1NWMjOpcx9bridn5yxLDX2gQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -4443,7 +4562,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       p-locate: 4.1.0
-    dev: true
 
   /locate-path/6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
@@ -4611,6 +4729,17 @@ packages:
     resolution: {integrity: sha512-3KYa4m4Vlqx98GPdOHghxSdNtTvcP8E0kkaJ5Dlh+h2DRzF7zpuVVcA8B0QpKd11YJeP9QQ7ASkKzOeu195Wzw==}
     engines: {node: '>= 8.0.0'}
     dev: true
+
+  /motion/10.15.3:
+    resolution: {integrity: sha512-4QRYuHv4FlNWxiZjqad0ruQOjUP9AvZA//hk/O6K9VZkj4HEbHiSbPOGTQy3v01LZvyB1XTUpC6ouddcXWI+6Q==}
+    dependencies:
+      '@motionone/animation': 10.15.1
+      '@motionone/dom': 10.15.3
+      '@motionone/svelte': 10.15.3
+      '@motionone/types': 10.15.1
+      '@motionone/utils': 10.15.1
+      '@motionone/vue': 10.15.3
+    dev: false
 
   /ms/2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
@@ -4864,7 +4993,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       p-limit: 2.3.0
-    dev: true
 
   /p-locate/5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
@@ -4913,7 +5041,6 @@ packages:
   /path-exists/4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
-    dev: true
 
   /path-is-absolute/1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
@@ -5027,6 +5154,11 @@ packages:
     resolution: {integrity: sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==}
     engines: {node: '>=4.0.0'}
 
+  /pngjs/5.0.0:
+    resolution: {integrity: sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==}
+    engines: {node: '>=10.13.0'}
+    dev: false
+
   /postcss-load-config/3.1.4:
     resolution: {integrity: sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==}
     engines: {node: '>= 10'}
@@ -5090,6 +5222,10 @@ packages:
     resolution: {integrity: sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q==}
     dev: false
 
+  /proxy-compare/2.4.0:
+    resolution: {integrity: sha512-FD8KmQUQD6Mfpd0hywCOzcon/dbkFP8XBd9F1ycbKtvVsfv6TsFUKJ2eC0Iz2y+KzlkdT1Z8SY6ZSgm07zOyqg==}
+    dev: false
+
   /pseudomap/1.0.2:
     resolution: {integrity: sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==}
     dev: true
@@ -5110,6 +5246,17 @@ packages:
       isarray: 2.0.5
       pngjs: 3.4.0
       yargs: 13.3.2
+
+  /qrcode/1.5.1:
+    resolution: {integrity: sha512-nS8NJ1Z3md8uTjKtP+SGGhfqmTCs5flU/xR623oI0JX+Wepz9R8UrRVCTBTJm3qGw3rH6jJ6MUHjkDx15cxSSg==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
+    dependencies:
+      dijkstrajs: 1.0.2
+      encode-utf8: 1.0.3
+      pngjs: 5.0.0
+      yargs: 15.4.1
+    dev: false
 
   /qs/6.11.0:
     resolution: {integrity: sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==}
@@ -5603,7 +5750,6 @@ packages:
       emoji-regex: 8.0.0
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
-    dev: true
 
   /string-width/5.1.2:
     resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
@@ -5646,7 +5792,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       ansi-regex: 5.0.1
-    dev: true
 
   /strip-ansi/7.0.1:
     resolution: {integrity: sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==}
@@ -5671,7 +5816,7 @@ packages:
     dev: true
 
   /strip-hex-prefix/1.0.0:
-    resolution: {integrity: sha1-DF8VX+8RUTczd96du1iNoFUA428=}
+    resolution: {integrity: sha512-q8d4ue7JGEiVcypji1bALTos+0pWtyGlivAWyPuTkHzuTCJqrK9sWxYQZUq6Nq3cuyv3bm734IhHvHtGGURU6A==}
     engines: {node: '>=6.5.0', npm: '>=3'}
     dependencies:
       is-hex-prefixed: 1.0.0
@@ -5996,7 +6141,6 @@ packages:
     resolution: {integrity: sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
-    dev: true
 
   /utf-8-validate/5.0.10:
     resolution: {integrity: sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==}
@@ -6031,6 +6175,19 @@ packages:
       spdx-correct: 3.1.1
       spdx-expression-parse: 3.0.1
     dev: true
+
+  /valtio/1.8.2:
+    resolution: {integrity: sha512-ypFWPi3aY04tojWAFPbTYBDw5iFaCDbKAJ2XqhmY2XOSorNtaCZJNg++FSssv8gMJwmPXfrU/RjncQtsoOHbUg==}
+    engines: {node: '>=12.7.0'}
+    peerDependencies:
+      react: '>=16.8'
+    peerDependenciesMeta:
+      react:
+        optional: true
+    dependencies:
+      proxy-compare: 2.4.0
+      use-sync-external-store: 1.2.0
+    dev: false
 
   /vite/3.2.2:
     resolution: {integrity: sha512-pLrhatFFOWO9kS19bQ658CnRYzv0WLbsPih6R+iFeEEhDOuYgYCX2rztUViMz/uy/V8cLCJvLFeiOK7RJEzHcw==}
@@ -6218,7 +6375,6 @@ packages:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
-    dev: true
 
   /wrap-ansi/7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
@@ -6326,7 +6482,6 @@ packages:
     dependencies:
       camelcase: 5.3.1
       decamelize: 1.2.0
-    dev: true
 
   /yargs-parser/21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
@@ -6362,7 +6517,6 @@ packages:
       which-module: 2.0.0
       y18n: 4.0.3
       yargs-parser: 18.1.3
-    dev: true
 
   /yargs/17.6.0:
     resolution: {integrity: sha512-8H/wTDqlSwoSnScvV2N/JHfLWOKuh5MVla9hqLjK3nsfyy6Y4kDSYSvkU5YCUEPOSnRXfIyx3Sq+B/IWudTo4g==}


### PR DESCRIPTION
## Description

Replaces legacy `qrcode-modal` with standalone version of new web3modal. Added guard to not create / initiate new WalletConnect provider every time `connect` method is called in v2, as same socket can be reused.

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/references/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

## Tests
- Tested v1 implementation with metamask / rainbow wallet using docs example page
- Tested v2 implementation with new web3modal and universal-provider via Trust wallet using docs example
- Tested closing the modal and throwing an error
- Tested rejecting connection within wallet and throwing an error

Your ENS/address: asimetriq.eth
