### PR TITLE
Update optimism explorer to the official proxy

### DIFF
--- a/.changeset/quiet-berries-hug.md
+++ b/.changeset/quiet-berries-hug.md
@@ -1,0 +1,5 @@
+---
+'@wagmi/chains': patch
+---
+
+Updated optimism block explorer uri to the official proxy managed by op labs

--- a/packages/chains/src/optimism.ts
+++ b/packages/chains/src/optimism.ts
@@ -15,7 +15,7 @@ export const optimism: Chain = {
       webSocket: ['wss://optimism-mainnet.infura.io/ws/v3'],
     },
     default: {
-      http: ['https://mainnet.optimism.io'],
+      http: ['https://explorer.optimism.io'],
     },
   },
   blockExplorers: {

--- a/packages/chains/src/optimism.ts
+++ b/packages/chains/src/optimism.ts
@@ -15,7 +15,7 @@ export const optimism: Chain = {
       webSocket: ['wss://optimism-mainnet.infura.io/ws/v3'],
     },
     default: {
-      http: ['https://explorer.optimism.io'],
+      http: ['https://mainnet.optimism.io'],
     },
   },
   blockExplorers: {
@@ -24,8 +24,8 @@ export const optimism: Chain = {
       url: 'https://optimistic.etherscan.io',
     },
     default: {
-      name: 'Etherscan',
-      url: 'https://optimistic.etherscan.io',
+      name: 'Optimism Explorer',
+      url: 'https://explorer.optimism.io',
     },
   },
   contracts: {


### PR DESCRIPTION
Update explorer for optimism to the official proxy.  As of today it proxies to etherscan but that may change