### PR TITLE
Add Trust Wallet Connector

### DIFF
--- a/packages/connectors/package.json
+++ b/packages/connectors/package.json
@@ -61,6 +61,10 @@
       "types": "./dist/ledger.d.ts",
       "default": "./dist/ledger.js"
     },
+    "./trustWallet": {
+      "types": "./dist/trustWallet.d.ts",
+      "default": "./dist/trustWallet.js"
+    },
     "./package.json": "./package.json"
   },
   "files": [
@@ -70,7 +74,8 @@
     "/metaMask",
     "/mock",
     "/walletConnect",
-    "/ledger"
+    "/ledger",
+    "/trustWallet"
   ],
   "sideEffects": false,
   "contributors": [

--- a/packages/connectors/src/trustWallet.test.ts
+++ b/packages/connectors/src/trustWallet.test.ts
@@ -1,0 +1,13 @@
+import { testChains } from '@wagmi/core/internal/test'
+import { describe, expect, it } from 'vitest'
+
+import { TrustWalletConnector } from './trustWallet'
+
+describe('TrustWalletConnector', () => {
+  it('inits', () => {
+    const connector = new TrustWalletConnector({
+      chains: testChains,
+    })
+    expect(connector.name).toEqual('Trust Wallet')
+  })
+})

--- a/packages/connectors/src/trustWallet.ts
+++ b/packages/connectors/src/trustWallet.ts
@@ -1,0 +1,97 @@
+import { Chain, Ethereum, UserRejectedRequestError } from '@wagmi/core'
+import { providers } from 'ethers'
+import { getAddress } from 'ethers/lib/utils.js'
+
+import { ConnectorData } from './base'
+import { InjectedConnector, InjectedConnectorOptions } from './injected'
+
+export class TrustWalletConnector extends InjectedConnector {
+  readonly id = 'trustWallet'
+
+  constructor({
+    chains,
+    options: options_,
+  }: {
+    chains?: Chain[]
+    options?: InjectedConnectorOptions
+  } = {}) {
+    const options = {
+      name: 'Trust Wallet',
+      getProvider() {
+        function isTrust(ethereum?: Ethereum) {
+          const isTrustWallet = !!ethereum?.isTrust || !!ethereum?.isTrustWallet
+          if (!isTrustWallet) return
+          return ethereum
+        }
+
+        if (typeof window === 'undefined') return
+
+        const provider =
+          isTrust(window.ethereum) ||
+          window.trustwallet ||
+          window.ethereum?.providers?.find(isTrust)
+
+        if (provider) {
+          return provider
+        }
+
+        window.open('https://trustwallet.com/browser-extension/', '_blank')
+      },
+      ...options_,
+    }
+    super({ chains, options })
+  }
+
+  async connect(
+    config?: { chainId?: number | undefined } | undefined,
+  ): Promise<Required<ConnectorData<any>>> {
+    try {
+      const provider = await this.getProvider()
+      let account: string
+
+      provider.on('connect', this.connect)
+      provider.on('accountsChanged', this.onAccountsChanged)
+      provider.on('chainChanged', this.onChainChanged)
+      provider.on('disconnect', this.onDisconnect)
+
+      const id = await this.getChainId()
+      const unsupported = this.isChainUnsupported(id)
+
+      try {
+        await provider.request({
+          method: 'wallet_requestPermissions',
+          params: [{ eth_accounts: {} }],
+        })
+        account = await this.getAccount()
+      } catch (error) {
+        if (this.isUserRejectedRequestError(error)) {
+          throw new UserRejectedRequestError(error)
+        }
+      }
+
+      if (!account) {
+        const accounts = await provider.request({
+          method: 'eth_requestAccounts',
+        })
+        account = getAddress(accounts[0] as string)
+      }
+
+      if (config?.chainId && id !== config?.chainId) {
+        this.switchChain(config.chainId)
+      }
+
+      return {
+        account,
+        chain: { id, unsupported },
+        provider: new providers.Web3Provider(
+          provider as unknown as providers.ExternalProvider,
+        ),
+      }
+    } catch (error) {
+      if (this.isUserRejectedRequestError(error)) {
+        throw new UserRejectedRequestError(error)
+      }
+      throw error
+    }
+  }
+}

--- a/packages/connectors/src/trustWallet.ts
+++ b/packages/connectors/src/trustWallet.ts
@@ -27,6 +27,7 @@ export class TrustWalletConnector extends InjectedConnector {
   } = {}) {
     const options = {
       name: 'Trust Wallet',
+      shimDisconnect: true,
       getProvider() {
         function isTrust(ethereum?: Ethereum) {
           const isTrustWallet = !!ethereum?.isTrust || !!ethereum?.isTrustWallet

--- a/packages/connectors/tsup.config.ts
+++ b/packages/connectors/tsup.config.ts
@@ -14,6 +14,7 @@ export default defineConfig(
       'src/mock/index.ts',
       'src/walletConnect.ts',
       'src/ledger.ts',
+      'src/trustWallet.ts',
     ],
     external: [...Object.keys(dependencies), ...Object.keys(peerDependencies)],
     platform: 'browser',


### PR DESCRIPTION
## Description

Custom connector for Trust Wallet Browser Extension. 

Makes it possible to connect to Trust Wallet when several wallet extensions are installed. 

Redirects user to installation resources page when trying to connect to Trust Wallet, and extension is not available. 


## Additional Information

- [x] I've read the [contributing docs](/wagmi-dev/references/blob/main/.github/CONTRIBUTING.md)