### PR TITLE
Fixes issue 1664. SwitchNetwork exposes API keys when adding a new network

### DIFF
--- a/.changeset/nasty-coins-poke.md
+++ b/.changeset/nasty-coins-poke.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/chains": patch
+---
+
+Added `public` RPC URLs to Chains for public RPC endpoints. 

--- a/packages/chains/src/arbitrum.ts
+++ b/packages/chains/src/arbitrum.ts
@@ -17,6 +17,9 @@ export const arbitrum: Chain = {
     default: {
       http: ['https://arb1.arbitrum.io/rpc'],
     },
+    public: {
+      http: ['https://arb1.arbitrum.io/rpc'],
+    },
   },
   blockExplorers: {
     etherscan: { name: 'Arbiscan', url: 'https://arbiscan.io' },

--- a/packages/chains/src/arbitrumGoerli.ts
+++ b/packages/chains/src/arbitrumGoerli.ts
@@ -21,6 +21,9 @@ export const arbitrumGoerli: Chain = {
     default: {
       http: ['https://goerli-rollup.arbitrum.io/rpc'],
     },
+    public: {
+      http: ['https://goerli-rollup.arbitrum.io/rpc'],
+    },
   },
   blockExplorers: {
     etherscan: { name: 'Arbiscan', url: 'https://goerli.arbiscan.io/' },

--- a/packages/chains/src/avalanche.ts
+++ b/packages/chains/src/avalanche.ts
@@ -11,6 +11,7 @@ export const avalanche: Chain = {
   },
   rpcUrls: {
     default: { http: ['https://api.avax.network/ext/bc/C/rpc'] },
+    public: { http: ['https://api.avax.network/ext/bc/C/rpc'] },
   },
   blockExplorers: {
     etherscan: { name: 'SnowTrace', url: 'https://snowtrace.io' },

--- a/packages/chains/src/avalancheFuji.ts
+++ b/packages/chains/src/avalancheFuji.ts
@@ -11,6 +11,7 @@ export const avalancheFuji: Chain = {
   },
   rpcUrls: {
     default: { http: ['https://api.avax-test.network/ext/bc/C/rpc'] },
+    public: { http: ['https://api.avax-test.network/ext/bc/C/rpc'] },
   },
   blockExplorers: {
     etherscan: { name: 'SnowTrace', url: 'https://testnet.snowtrace.io' },

--- a/packages/chains/src/bsc.ts
+++ b/packages/chains/src/bsc.ts
@@ -11,6 +11,7 @@ export const bsc: Chain = {
   },
   rpcUrls: {
     default: { http: ['https://rpc.ankr.com/bsc'] },
+    public: { http: ['https://rpc.ankr.com/bsc'] },
   },
   blockExplorers: {
     etherscan: { name: 'BscScan', url: 'https://bscscan.com' },

--- a/packages/chains/src/bscTestnet.ts
+++ b/packages/chains/src/bscTestnet.ts
@@ -11,6 +11,7 @@ export const bscTestnet: Chain = {
   },
   rpcUrls: {
     default: { http: ['https://bsc-testnet.public.blastapi.io'] },
+    public: { http: ['https://bsc-testnet.public.blastapi.io'] },
   },
   blockExplorers: {
     etherscan: { name: 'BscScan', url: 'https://testnet.bscscan.com' },

--- a/packages/chains/src/evmos.ts
+++ b/packages/chains/src/evmos.ts
@@ -11,6 +11,7 @@ export const evmos: Chain = {
   },
   rpcUrls: {
     default: { http: ['https://eth.bd.evmos.org:8545'] },
+    public: { http: ['https://eth.bd.evmos.org:8545'] },
   },
   blockExplorers: {
     default: { name: 'Evmos Block Explorer', url: 'https://escan.live/' },

--- a/packages/chains/src/evmosTestnet.ts
+++ b/packages/chains/src/evmosTestnet.ts
@@ -11,6 +11,7 @@ export const evmosTestnet: Chain = {
   },
   rpcUrls: {
     default: { http: ['https://eth.bd.evmos.dev:8545'] },
+    public: { http: ['https://eth.bd.evmos.dev:8545'] },
   },
   blockExplorers: {
     default: {

--- a/packages/chains/src/fantom.ts
+++ b/packages/chains/src/fantom.ts
@@ -11,6 +11,7 @@ export const fantom: Chain = {
   },
   rpcUrls: {
     default: { http: ['https://rpc.ankr.com/fantom'] },
+    public: { http: ['https://rpc.ankr.com/fantom'] },
   },
   blockExplorers: {
     etherscan: { name: 'FTMScan', url: 'https://ftmscan.com' },

--- a/packages/chains/src/fantomTestnet.ts
+++ b/packages/chains/src/fantomTestnet.ts
@@ -11,6 +11,7 @@ export const fantomTestnet: Chain = {
   },
   rpcUrls: {
     default: { http: ['https://rpc.testnet.fantom.network'] },
+    public: { http: ['https://rpc.testnet.fantom.network'] },
   },
   blockExplorers: {
     etherscan: { name: 'FTMScan', url: 'https://testnet.ftmscan.com' },

--- a/packages/chains/src/foundry.ts
+++ b/packages/chains/src/foundry.ts
@@ -11,5 +11,6 @@ export const foundry: Chain = {
   },
   rpcUrls: {
     default: { http: ['http://127.0.0.1:8545'] },
+    public: { http: ['http://127.0.0.1:8545'] },
   },
 }

--- a/packages/chains/src/gnosis.ts
+++ b/packages/chains/src/gnosis.ts
@@ -11,6 +11,7 @@ export const gnosis: Chain = {
   },
   rpcUrls: {
     default: { http: ['https://rpc.gnosischain.com'] },
+    public: { http: ['https://rpc.gnosischain.com'] },
   },
   blockExplorers: {
     etherscan: {

--- a/packages/chains/src/goerli.ts
+++ b/packages/chains/src/goerli.ts
@@ -17,6 +17,9 @@ export const goerli: Chain = {
     default: {
       http: ['https://rpc.ankr.com/eth_goerli'],
     },
+    public: {
+      http: ['https://rpc.ankr.com/eth_goerli'],
+    },
   },
   blockExplorers: {
     etherscan: {

--- a/packages/chains/src/hardhat.ts
+++ b/packages/chains/src/hardhat.ts
@@ -11,5 +11,6 @@ export const hardhat: Chain = {
   },
   rpcUrls: {
     default: { http: ['http://127.0.0.1:8545'] },
+    public: { http: ['http://127.0.0.1:8545'] },
   },
 }

--- a/packages/chains/src/iotex.ts
+++ b/packages/chains/src/iotex.ts
@@ -14,6 +14,10 @@ export const iotex: Chain = {
       http: ['https://babel-api.mainnet.iotex.io'],
       webSocket: ['wss://babel-api.mainnet.iotex.io'],
     },
+    public: {
+      http: ['https://babel-api.mainnet.iotex.io'],
+      webSocket: ['wss://babel-api.mainnet.iotex.io'],
+    },
   },
   blockExplorers: {
     default: { name: 'IoTeXScan', url: 'https://iotexscan.io' },

--- a/packages/chains/src/iotexTestnet.ts
+++ b/packages/chains/src/iotexTestnet.ts
@@ -14,6 +14,10 @@ export const iotexTestnet: Chain = {
       http: ['https://babel-api.testnet.iotex.io'],
       webSocket: ['wss://babel-api.testnet.iotex.io'],
     },
+    public: {
+      http: ['https://babel-api.testnet.iotex.io'],
+      webSocket: ['wss://babel-api.testnet.iotex.io'],
+    },
   },
   blockExplorers: {
     default: { name: 'IoTeXScan', url: 'https://testnet.iotexscan.io' },

--- a/packages/chains/src/localhost.ts
+++ b/packages/chains/src/localhost.ts
@@ -11,5 +11,6 @@ export const localhost: Chain = {
   },
   rpcUrls: {
     default: { http: ['http://127.0.0.1:8545'] },
+    public: { http: ['http://127.0.0.1:8545'] },
   },
 }

--- a/packages/chains/src/mainnet.ts
+++ b/packages/chains/src/mainnet.ts
@@ -17,6 +17,9 @@ export const mainnet: Chain = {
     default: {
       http: ['https://cloudflare-eth.com'],
     },
+    public: {
+      http: ['https://cloudflare-eth.com'],
+    },
   },
   blockExplorers: {
     etherscan: {

--- a/packages/chains/src/metis.ts
+++ b/packages/chains/src/metis.ts
@@ -11,6 +11,7 @@ export const metis: Chain = {
   },
   rpcUrls: {
     default: { http: ['https://andromeda.metis.io/?owner=1088'] },
+    public: { http: ['https://andromeda.metis.io/?owner=1088'] },
   },
   blockExplorers: {
     default: {

--- a/packages/chains/src/metisGoerli.ts
+++ b/packages/chains/src/metisGoerli.ts
@@ -11,6 +11,7 @@ export const metisGoerli: Chain = {
   },
   rpcUrls: {
     default: { http: ['https://goerli.gateway.metisdevops.link'] },
+    public: { http: ['https://goerli.gateway.metisdevops.link'] },
   },
   blockExplorers: {
     default: {

--- a/packages/chains/src/optimism.ts
+++ b/packages/chains/src/optimism.ts
@@ -17,6 +17,9 @@ export const optimism: Chain = {
     default: {
       http: ['https://mainnet.optimism.io'],
     },
+    public: {
+      http: ['https://mainnet.optimism.io'],
+    },
   },
   blockExplorers: {
     etherscan: {

--- a/packages/chains/src/optimismGoerli.ts
+++ b/packages/chains/src/optimismGoerli.ts
@@ -17,6 +17,9 @@ export const optimismGoerli: Chain = {
     default: {
       http: ['https://goerli.optimism.io'],
     },
+    public: {
+      http: ['https://goerli.optimism.io'],
+    },
   },
   blockExplorers: {
     etherscan: {

--- a/packages/chains/src/polygon.ts
+++ b/packages/chains/src/polygon.ts
@@ -17,6 +17,9 @@ export const polygon: Chain = {
     default: {
       http: ['https://polygon-rpc.com'],
     },
+    public: {
+      http: ['https://polygon-rpc.com'],
+    },
   },
   blockExplorers: {
     etherscan: {

--- a/packages/chains/src/polygonMumbai.ts
+++ b/packages/chains/src/polygonMumbai.ts
@@ -17,6 +17,9 @@ export const polygonMumbai: Chain = {
     default: {
       http: ['https://matic-mumbai.chainstacklabs.com'],
     },
+    public: {
+      http: ['https://matic-mumbai.chainstacklabs.com'],
+    },
   },
   blockExplorers: {
     etherscan: {

--- a/packages/chains/src/sepolia.ts
+++ b/packages/chains/src/sepolia.ts
@@ -13,6 +13,9 @@ export const sepolia: Chain = {
     default: {
       http: ['https://rpc.sepolia.org'],
     },
+    public: {
+      http: ['https://rpc.sepolia.org'],
+    },
   },
   blockExplorers: {
     etherscan: {

--- a/packages/chains/src/taraxa.ts
+++ b/packages/chains/src/taraxa.ts
@@ -9,6 +9,9 @@ export const taraxa: Chain = {
     default: {
       http: ['https://rpc.mainnet.taraxa.io'],
     },
+    public: {
+      http: ['https://rpc.mainnet.taraxa.io'],
+    },
   },
   blockExplorers: {
     default: {

--- a/packages/chains/src/taraxaTestnet.ts
+++ b/packages/chains/src/taraxaTestnet.ts
@@ -9,6 +9,9 @@ export const taraxaTestnet: Chain = {
     default: {
       http: ['https://rpc.testnet.taraxa.io'],
     },
+    public: {
+      http: ['https://rpc.testnet.taraxa.io'],
+    },
   },
   blockExplorers: {
     default: {

--- a/packages/chains/src/types.ts
+++ b/packages/chains/src/types.ts
@@ -18,6 +18,7 @@ export type Chain = {
   rpcUrls: {
     [key: string]: RpcUrls
     default: RpcUrls
+    public: RpcUrls
   }
   /** Collection of block explorers */
   blockExplorers?: {

--- a/packages/chains/src/zkSync.ts
+++ b/packages/chains/src/zkSync.ts
@@ -14,6 +14,10 @@ export const zkSync: Chain = {
       http: ['https://zksync2-mainnet.zksync.io'],
       webSocket: ['wss://zksync2-mainnet.zksync.io/ws'],
     },
+    public: {
+      http: ['https://zksync2-mainnet.zksync.io'],
+      webSocket: ['wss://zksync2-mainnet.zksync.io/ws'],
+    },
   },
   blockExplorers: {
     default: {

--- a/packages/chains/src/zkSyncTestnet.ts
+++ b/packages/chains/src/zkSyncTestnet.ts
@@ -10,6 +10,10 @@ export const zkSyncTestnet: Chain = {
       http: ['https://zksync2-testnet.zksync.dev'],
       webSocket: ['wss://zksync2-testnet.zksync.dev/ws'],
     },
+    public: {
+      http: ['https://zksync2-testnet.zksync.dev'],
+      webSocket: ['wss://zksync2-testnet.zksync.dev/ws'],
+    },
   },
   blockExplorers: {
     default: {

--- a/packages/connectors/src/coinbaseWallet.ts
+++ b/packages/connectors/src/coinbaseWallet.ts
@@ -216,10 +216,7 @@ export class CoinbaseWalletConnector extends Connector<
                 chainId: id,
                 chainName: chain.name,
                 nativeCurrency: chain.nativeCurrency,
-                rpcUrls: [
-                  chain.rpcUrls.public?.http[0] ??
-                    chain.rpcUrls.default.http[0],
-                ],
+                rpcUrls: [chain.rpcUrls.public?.http[0] ?? ''],
                 blockExplorerUrls: this.getBlockExplorerUrls(chain),
               },
             ],

--- a/packages/connectors/src/injected.ts
+++ b/packages/connectors/src/injected.ts
@@ -234,11 +234,7 @@ export class InjectedConnector extends Connector<
                 chainId: id,
                 chainName: chain.name,
                 nativeCurrency: chain.nativeCurrency,
-                rpcUrls: [
-                  chain.rpcUrls.public?.http[0] ??
-                    chain.rpcUrls.default.http[0] ??
-                    '',
-                ],
+                rpcUrls: [chain.rpcUrls.public?.http[0] ?? ''],
                 blockExplorerUrls: this.getBlockExplorerUrls(chain),
               },
             ],


### PR DESCRIPTION
## Description

Check https://github.com/wagmi-dev/wagmi/issues/1664

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/wagmi/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address:
nfts2me.eth

See past PR for context: https://github.com/wagmi-dev/wagmi/pull/1665