### PR TITLE
fix: add public RPC url to Connector fallback chains

### DIFF
--- a/.changeset/hungry-hats-sit.md
+++ b/.changeset/hungry-hats-sit.md
@@ -1,0 +1,5 @@
+---
+'@wagmi/connectors': patch
+---
+
+Added public RPC URL to Connector fallback chains

--- a/packages/connectors/src/coinbaseWallet.ts
+++ b/packages/connectors/src/coinbaseWallet.ts
@@ -202,7 +202,7 @@ export class CoinbaseWalletConnector extends Connector<
           name: `Chain ${id}`,
           network: `${id}`,
           nativeCurrency: { name: 'Ether', decimals: 18, symbol: 'ETH' },
-          rpcUrls: { default: { http: [''] } },
+          rpcUrls: { default: { http: [''] }, public: { http: [''] } },
         }
       )
     } catch (error) {

--- a/packages/connectors/src/injected.ts
+++ b/packages/connectors/src/injected.ts
@@ -210,7 +210,7 @@ export class InjectedConnector extends Connector<
           name: `Chain ${id}`,
           network: `${id}`,
           nativeCurrency: { name: 'Ether', decimals: 18, symbol: 'ETH' },
-          rpcUrls: { default: { http: [''] } },
+          rpcUrls: { default: { http: [''] }, public: { http: [''] } },
         }
       )
     } catch (error) {

--- a/packages/connectors/src/mock/connector.ts
+++ b/packages/connectors/src/mock/connector.ts
@@ -114,7 +114,7 @@ export class MockConnector extends Connector<
         name: `Chain ${chainId}`,
         network: `${chainId}`,
         nativeCurrency: { name: 'Ether', decimals: 18, symbol: 'ETH' },
-        rpcUrls: { default: { http: [''] } },
+        rpcUrls: { default: { http: [''] }, public: { http: [''] } },
       }
     )
   }

--- a/packages/connectors/src/walletConnect.ts
+++ b/packages/connectors/src/walletConnect.ts
@@ -427,7 +427,7 @@ export class WalletConnectConnector extends Connector<
           name: `Chain ${id}`,
           network: `${id}`,
           nativeCurrency: { decimals: 18, name: 'Ether', symbol: 'ETH' },
-          rpcUrls: { default: { http: [''] } },
+          rpcUrls: { default: { http: [''] }, public: { http: [''] } },
         }
       )
     } catch (error) {


### PR DESCRIPTION
## Description

Adds `public` to Chain `rpcUrls` to fix fallback chains

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/references/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: awkweb.eth
