### PR TITLE
fix(connectors): abitype mismatch

### DIFF
--- a/.changeset/khaki-buttons-do.md
+++ b/.changeset/khaki-buttons-do.md
@@ -1,0 +1,5 @@
+---
+'@wagmi/connectors': patch
+---
+
+Fixed ABIType version mismatch between packages.

--- a/packages/connectors/package.json
+++ b/packages/connectors/package.json
@@ -22,7 +22,6 @@
     "@walletconnect/ethereum-provider": "^1.8.0",
     "@web3modal/standalone": "^2.0.0-rc.2",
     "@walletconnect/universal-provider": "^2.2.1",
-    "abitype": "^0.1.8",
     "eventemitter3": "^4.0.7"
   },
   "devDependencies": {

--- a/packages/connectors/src/base.ts
+++ b/packages/connectors/src/base.ts
@@ -1,6 +1,6 @@
+import type { Address } from '@wagmi/core'
 import type { Chain } from '@wagmi/core/chains'
 import { goerli, mainnet } from '@wagmi/core/chains'
-import type { Address } from 'abitype'
 import { default as EventEmitter } from 'eventemitter3'
 
 export type ConnectorData<Provider = any> = {

--- a/packages/connectors/src/coinbaseWallet.ts
+++ b/packages/connectors/src/coinbaseWallet.ts
@@ -3,7 +3,6 @@ import type {
   CoinbaseWalletSDK,
 } from '@coinbase/wallet-sdk'
 import type { CoinbaseWalletSDKOptions } from '@coinbase/wallet-sdk/dist/CoinbaseWalletSDK'
-import type { ProviderRpcError } from '@wagmi/core'
 import {
   AddChainError,
   ChainNotConfiguredError,
@@ -11,8 +10,8 @@ import {
   UserRejectedRequestError,
   normalizeChainId,
 } from '@wagmi/core'
+import type { Address, ProviderRpcError } from '@wagmi/core'
 import type { Chain } from '@wagmi/core/chains'
-import type { Address } from 'abitype'
 import { providers } from 'ethers'
 import { getAddress, hexValue } from 'ethers/lib/utils.js'
 

--- a/packages/connectors/src/injected.ts
+++ b/packages/connectors/src/injected.ts
@@ -1,4 +1,3 @@
-import type { ProviderRpcError, RpcError } from '@wagmi/core'
 import {
   AddChainError,
   ChainNotConfiguredError,
@@ -9,8 +8,8 @@ import {
   getClient,
   normalizeChainId,
 } from '@wagmi/core'
+import type { Address, ProviderRpcError, RpcError } from '@wagmi/core'
 import type { Chain } from '@wagmi/core/chains'
-import type { Address } from 'abitype'
 import { providers } from 'ethers'
 import { getAddress, hexValue } from 'ethers/lib/utils.js'
 

--- a/packages/connectors/src/metaMask.ts
+++ b/packages/connectors/src/metaMask.ts
@@ -4,9 +4,8 @@ import {
   UserRejectedRequestError,
   getClient,
 } from '@wagmi/core'
-import type { Ethereum, RpcError } from '@wagmi/core'
+import type { Address, Ethereum, RpcError } from '@wagmi/core'
 import type { Chain } from '@wagmi/core/chains'
-import type { Address } from 'abitype'
 import { getAddress } from 'ethers/lib/utils.js'
 
 import type { InjectedConnectorOptions } from './injected'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,7 +73,6 @@ importers:
       '@walletconnect/ethereum-provider': ^1.8.0
       '@walletconnect/universal-provider': ^2.2.1
       '@web3modal/standalone': ^2.0.0-rc.2
-      abitype: ^0.1.8
       ethers: ^5.7.2
       eventemitter3: ^4.0.7
     dependencies:
@@ -82,7 +81,6 @@ importers:
       '@walletconnect/ethereum-provider': 1.8.0
       '@walletconnect/universal-provider': 2.2.1
       '@web3modal/standalone': 2.0.0-rc.2
-      abitype: 0.1.8
       eventemitter3: 4.0.7
     devDependencies:
       '@wagmi/core': 0.8.12_egrf7ew7xcibj7pkaydxy7nghq
@@ -2009,6 +2007,7 @@ packages:
     engines: {pnpm: '>=7'}
     peerDependencies:
       typescript: '>=4.7.4'
+    dev: true
 
   /abitype/0.2.5:
     resolution: {integrity: sha512-t1iiokWYpkrziu4WL2Gb6YdGvaP9ZKs7WnA39TI8TsW2E99GVRgDPW/xOKhzoCdyxOYt550CNYEFluCwGaFHaA==}
@@ -4196,7 +4195,7 @@ packages:
     dev: true
 
   /is-hex-prefixed/1.0.0:
-    resolution: {integrity: sha512-WvtOiug1VFrE9v1Cydwm+FnXd3+w9GaeVUss5W4v/SLy3UW00vP+6iNF2SdnfiBoLy4bTqVdkftNGTUeOFVsbA==}
+    resolution: {integrity: sha1-fY035q135dEnFIkTxXPggtd39VQ=}
     engines: {node: '>=6.5.0', npm: '>=3'}
 
   /is-interactive/1.0.0:
@@ -5815,7 +5814,7 @@ packages:
     dev: true
 
   /strip-hex-prefix/1.0.0:
-    resolution: {integrity: sha512-q8d4ue7JGEiVcypji1bALTos+0pWtyGlivAWyPuTkHzuTCJqrK9sWxYQZUq6Nq3cuyv3bm734IhHvHtGGURU6A==}
+    resolution: {integrity: sha1-DF8VX+8RUTczd96du1iNoFUA428=}
     engines: {node: '>=6.5.0', npm: '>=3'}
     dependencies:
       is-hex-prefixed: 1.0.0


### PR DESCRIPTION
## Description

Fixes ABIType mismatch between packages. `@wagmi/connector` `abitype` version was `0.1.8` while other downstream packages were on `0.2.5` (e.g. `wagmi`/`@wagmi/core`).

Should fix this issue once versions are bumped downstream: https://github.com/wagmi-dev/wagmi/issues/1712

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/references/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: awkweb.eth
