### PR TITLE
Fix: ensure chain update prior to resolving switchNetwork

### DIFF
--- a/.changeset/few-geckos-join.md
+++ b/.changeset/few-geckos-join.md
@@ -1,0 +1,5 @@
+---
+'@wagmi/connectors': minor
+---
+
+Fixed race condition between switchNetwork and state update

--- a/.changeset/few-geckos-join.md
+++ b/.changeset/few-geckos-join.md
@@ -2,4 +2,4 @@
 '@wagmi/connectors': minor
 ---
 
-Fixed race condition between switchNetwork and state update
+Fixed race condition between `switchNetwork` and mutation Hooks that use `chainId` (e.g. `sendTransaction`).

--- a/packages/connectors/src/injected.ts
+++ b/packages/connectors/src/injected.ts
@@ -202,15 +202,17 @@ export class InjectedConnector extends Connector<
     const id = hexValue(chainId)
 
     try {
-      await provider.request({
-        method: 'wallet_switchEthereumChain',
-        params: [{ chainId: id }],
-      })
-      await new Promise<void>((res) =>
-        this.on('change', ({ chain }) => {
-          if (chain?.id === chainId) res()
+      await Promise.all([
+        provider.request({
+          method: 'wallet_switchEthereumChain',
+          params: [{ chainId: id }],
         }),
-      )
+        new Promise<void>((res) =>
+          this.on('change', ({ chain }) => {
+            if (chain?.id === chainId) res()
+          }),
+        ),
+      ])
       return (
         this.chains.find((x) => x.id === chainId) ?? {
           id: chainId,

--- a/packages/connectors/src/injected.ts
+++ b/packages/connectors/src/injected.ts
@@ -206,6 +206,11 @@ export class InjectedConnector extends Connector<
         method: 'wallet_switchEthereumChain',
         params: [{ chainId: id }],
       })
+      await new Promise<void>((res) =>
+        this.on('change', ({ chain }) => {
+          if (chain?.id === chainId) res()
+        }),
+      )
       return (
         this.chains.find((x) => x.id === chainId) ?? {
           id: chainId,


### PR DESCRIPTION
## Description

Refer to: [wagmi-dev/wagmi#1565](https://github.com/wagmi-dev/wagmi/issues/1565)

Root issue: switchNetwork promise gets resolved prior to new state being set in response to MetaMask emitting 'chainChanged' event

Correction: Added check to ensure event has been received prior to resolving 

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/references/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: DanInTheD4rk.eth
