### PR TITLE
chore: lock ethers version

### DIFF
--- a/.changeset/early-tables-lick.md
+++ b/.changeset/early-tables-lick.md
@@ -1,0 +1,5 @@
+---
+'@wagmi/connectors': patch
+---
+
+Locked ethers peer dependency version to >=5.5.1 <6

--- a/packages/connectors/package.json
+++ b/packages/connectors/package.json
@@ -9,7 +9,7 @@
   },
   "peerDependencies": {
     "@wagmi/core": ">=0.9.x",
-    "ethers": ">=5.5.1",
+    "ethers": ">=5.5.1 <6",
     "typescript": ">=4.9.4"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
## Description

Locking `ethers@>=5.5.1 <6`

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/references/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: awkweb.eth
