### PR TITLE
update universal resolver addresses

### DIFF
--- a/packages/chains/src/goerli.ts
+++ b/packages/chains/src/goerli.ts
@@ -36,8 +36,8 @@ export const goerli = {
       address: '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e',
     },
     ensUniversalResolver: {
-      address: '0x687c30Cc44bFA39A1449e86E172BF002E7b3f0b0',
-      blockCreated: 7725078,
+      address: '0xA292E2E58d4ddEb29C33c63173d0E8B7a2A4c62e',
+      blockCreated: 8610406,
     },
     multicall3: {
       address: '0xca11bde05977b3631167028862be2a173976ca11',

--- a/packages/chains/src/mainnet.ts
+++ b/packages/chains/src/mainnet.ts
@@ -36,8 +36,8 @@ export const mainnet = {
       address: '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e',
     },
     ensUniversalResolver: {
-      address: '0x74E20Bd2A1fE0cdbe45b9A1d89cb7e0a45b36376',
-      blockCreated: 16172161,
+      address: '0xE4Acdd618deED4e6d2f03b9bf62dc6118FC9A4da',
+      blockCreated: 16773775,
     },
     multicall3: {
       address: '0xca11bde05977b3631167028862be2a173976ca11',


### PR DESCRIPTION
new universal resolver version was deployed to mainnet/goerli that fixes the following:
- CCIP-read resolution to resolvers that don’t use the resolve() function
- resolution for unknown labels (using square bracket notation e.g. [0x-stripped-namehash].something.eth)