### PR TITLE
Add name mapping for Phantom

### DIFF
--- a/.changeset/proud-trains-hang.md
+++ b/.changeset/proud-trains-hang.md
@@ -1,0 +1,5 @@
+---
+'@wagmi/connectors': patch
+---
+
+Added name mapping for Phantom

--- a/packages/connectors/src/utils/getInjectedName.test.ts
+++ b/packages/connectors/src/utils/getInjectedName.test.ts
@@ -37,6 +37,8 @@ describe.each([
   },
   { ethereum: { isOneInchIOSWallet: true }, expected: '1inch Wallet' },
   { ethereum: { isOneInchAndroidWallet: true }, expected: '1inch Wallet' },
+  { ethereum: { isPhantom: true }, expected: 'Phantom' },
+  { ethereum: { isPhantom: true, isMetaMask: true }, expected: 'Phantom' },
   { ethereum: { isPortal: true }, expected: 'Ripio Portal' },
   { ethereum: { isRainbow: true }, expected: 'Rainbow' },
   { ethereum: { isTally: true }, expected: 'Tally' },

--- a/packages/connectors/src/utils/getInjectedName.ts
+++ b/packages/connectors/src/utils/getInjectedName.ts
@@ -18,6 +18,7 @@ export function getInjectedName(ethereum?: Ethereum) {
     if (provider.isOneInchIOSWallet || provider.isOneInchAndroidWallet)
       return '1inch Wallet'
     if (provider.isOpera) return 'Opera'
+    if (provider.isPhantom) return 'Phantom'
     if (provider.isPortal) return 'Ripio Portal'
     if (provider.isRainbow) return 'Rainbow'
     if (provider.isTally) return 'Tally'


### PR DESCRIPTION
## Description

Adds a name mapping for [Phantom](https://phantom.app/). Note that the `isPhantom` [flag](https://github.com/wagmi-dev/references/blob/d2e0b0b35955dfa928c1f30aeafc2fac7f16376c/packages/connectors/src/types.ts#L63) already exists in this repo.

Thanks!

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/references/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: brianfriel.eth
