### PR TITLE
Add Uniswap Wallet to WalletConnect switchChainAllowedRegex

### DIFF
--- a/.changeset/gold-beans-destroy.md
+++ b/.changeset/gold-beans-destroy.md
@@ -1,0 +1,5 @@
+---
+'@wagmi/connectors': patch
+---
+
+Added "uniswap wallet" to the regex that determines wallets allowed to switch chains in the WalletConnect legacy connector

--- a/packages/connectors/src/walletConnectLegacy.ts
+++ b/packages/connectors/src/walletConnectLegacy.ts
@@ -18,8 +18,10 @@ import { Connector } from './base'
  * - MetaMask (metamask.io)
  * - Rainbow (rainbow.me)
  * - Trust Wallet (trustwallet.com)
+ * - Uniswap Wallet (uniswap.org)
  */
-const switchChainAllowedRegex = /(imtoken|metamask|rainbow|trust wallet)/i
+const switchChainAllowedRegex =
+  /(imtoken|metamask|rainbow|trust wallet|uniswap wallet)/i
 
 type WalletConnectOptions = ConstructorParameters<
   typeof WalletConnectProvider


### PR DESCRIPTION
## Description

Adds "uniswap wallet" to the `switchChainAllowedRegex` in the WalletConnect legacy connector.

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/references/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)
