### PR TITLE
Update ethereum provider

### DIFF
--- a/.changeset/friendly-turtles-press.md
+++ b/.changeset/friendly-turtles-press.md
@@ -1,0 +1,5 @@
+---
+'@wagmi/connectors': patch
+---
+
+Updated @walletconnect/ethereum-provider to 2.4.8

--- a/packages/connectors/package.json
+++ b/packages/connectors/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@coinbase/wallet-sdk": "^3.5.4",
     "@ledgerhq/connect-kit-loader": "^1.0.1",
-    "@walletconnect/ethereum-provider": "^2.4.7",
+    "@walletconnect/ethereum-provider": "^2.4.8",
     "@walletconnect/legacy-provider": "^2.0.0",
     "@safe-global/safe-apps-provider": "^0.15.2",
     "@safe-global/safe-apps-sdk": "^7.9.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,7 +81,7 @@ importers:
       '@safe-global/safe-apps-provider': ^0.15.2
       '@safe-global/safe-apps-sdk': ^7.9.0
       '@wagmi/core': ^0.8.19
-      '@walletconnect/ethereum-provider': ^2.4.7
+      '@walletconnect/ethereum-provider': ^2.4.8
       '@walletconnect/legacy-provider': ^2.0.0
       abitype: ^0.3.0
       ethers: ^5.7.2
@@ -91,12 +91,12 @@ importers:
       '@ledgerhq/connect-kit-loader': 1.0.1
       '@safe-global/safe-apps-provider': 0.15.2
       '@safe-global/safe-apps-sdk': 7.9.0
-      '@walletconnect/ethereum-provider': 2.4.7
+      '@walletconnect/ethereum-provider': 2.4.8
       '@walletconnect/legacy-provider': 2.0.0
       abitype: 0.3.0
       eventemitter3: 4.0.7
     devDependencies:
-      '@wagmi/core': 0.8.19_cpu725jl4zb3hrmzrkb7vvhtfu
+      '@wagmi/core': 0.8.19_5ygnv77uckkikin5qrzjrryeyi
       ethers: 5.7.2
 
 packages:
@@ -1438,7 +1438,7 @@ packages:
     dependencies:
       '@coinbase/wallet-sdk': 3.6.2
       '@ledgerhq/connect-kit-loader': 1.0.1
-      '@wagmi/core': 0.8.19_cpu725jl4zb3hrmzrkb7vvhtfu
+      '@wagmi/core': 0.8.19_5ygnv77uckkikin5qrzjrryeyi
       '@walletconnect/ethereum-provider': 1.8.0
       '@walletconnect/universal-provider': 2.3.3
       '@web3modal/standalone': 2.1.1
@@ -1461,7 +1461,7 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@wagmi/core/0.8.19_cpu725jl4zb3hrmzrkb7vvhtfu:
+  /@wagmi/core/0.8.19_5ygnv77uckkikin5qrzjrryeyi:
     resolution: {integrity: sha512-B1iXB4MRjxgoybZATRmBI7YEfUhpIl3aZGUjo5GXPU1SNtlXIA4/3wePlmLD64XzICXVBp99kynrrdlvJxc4gw==}
     peerDependencies:
       '@coinbase/wallet-sdk': '>=3.6.0'
@@ -1476,7 +1476,7 @@ packages:
       '@coinbase/wallet-sdk': 3.6.2
       '@wagmi/chains': 0.1.14
       '@wagmi/connectors': 0.1.10_mooqdejtc64te7v32kpdxu5uri
-      '@walletconnect/ethereum-provider': 2.4.7
+      '@walletconnect/ethereum-provider': 2.4.8
       abitype: 0.2.5
       ethers: 5.7.2
       eventemitter3: 4.0.7
@@ -1542,7 +1542,7 @@ packages:
       '@walletconnect/jsonrpc-ws-connection': 1.0.7
       '@walletconnect/keyvaluestorage': 1.0.2
       '@walletconnect/logger': 2.0.1
-      '@walletconnect/relay-api': 1.0.7
+      '@walletconnect/relay-api': 1.0.9
       '@walletconnect/relay-auth': 1.0.4
       '@walletconnect/safe-json': 1.0.1
       '@walletconnect/time': 1.0.2
@@ -1563,8 +1563,8 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@walletconnect/core/2.4.7:
-    resolution: {integrity: sha512-w92NrtziqrWs070HJICGh80Vp60PaXu06OjNvOnVZEorbTipCWx4xxgcC2NhsT4TCQ8r1FOut6ahLe1PILuRsg==}
+  /@walletconnect/core/2.4.8:
+    resolution: {integrity: sha512-OLyBNJyUfQNr1qlcCxqzu5bmNorOL6SqWOwA3LcxV+3+mbUk4fByFd8AJRzGFWf8kC3BRycLFivHh4QEeBNZ8Q==}
     dependencies:
       '@walletconnect/heartbeat': 1.2.0
       '@walletconnect/jsonrpc-provider': 1.0.6
@@ -1576,8 +1576,8 @@ packages:
       '@walletconnect/relay-auth': 1.0.4
       '@walletconnect/safe-json': 1.0.1
       '@walletconnect/time': 1.0.2
-      '@walletconnect/types': 2.4.7
-      '@walletconnect/utils': 2.4.7
+      '@walletconnect/types': 2.4.8
+      '@walletconnect/utils': 2.4.8
       events: 3.3.0
       lodash.isequal: 4.5.0
       pino: 7.11.0
@@ -1633,18 +1633,18 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@walletconnect/ethereum-provider/2.4.7:
-    resolution: {integrity: sha512-YLvVsUMYeRuMbAlLmH8NygpgR17aVH8P9/rvckGXQTMe+MWXOp75SgLTK+HNxl/8YHmmOFyDjWT2gS4+l8ew+Q==}
+  /@walletconnect/ethereum-provider/2.4.8:
+    resolution: {integrity: sha512-/opEQKEWDmZcaWlssR2QmIp80nwLLhZXxk2iJ/bFLNW4Uzn4IxvpNuFQ1mtzyhYMY0jgAM3QT8QpYXhWjV4xJg==}
     dependencies:
       '@walletconnect/jsonrpc-http-connection': 1.0.4
       '@walletconnect/jsonrpc-provider': 1.0.6
       '@walletconnect/jsonrpc-types': 1.0.2
       '@walletconnect/jsonrpc-utils': 1.0.4
-      '@walletconnect/sign-client': 2.4.7
-      '@walletconnect/types': 2.4.7
-      '@walletconnect/universal-provider': 2.4.7
-      '@walletconnect/utils': 2.4.7
-      '@web3modal/standalone': 2.1.1
+      '@walletconnect/sign-client': 2.4.8
+      '@walletconnect/types': 2.4.8
+      '@walletconnect/universal-provider': 2.4.8
+      '@walletconnect/utils': 2.4.8
+      '@web3modal/standalone': 2.2.0
       events: 3.3.0
     transitivePeerDependencies:
       - '@react-native-async-storage/async-storage'
@@ -1886,18 +1886,18 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@walletconnect/sign-client/2.4.7:
-    resolution: {integrity: sha512-x5uxnHQkNSn0QNXUdPEfwy4o1Vyi2QIWkDGUh+pfSP4s2vN0+IJAcwqBqkPn+zJ1X7eKYLs+v0ih1eieciYMPA==}
+  /@walletconnect/sign-client/2.4.8:
+    resolution: {integrity: sha512-i10SjiqbU1bm4HAS2aboznYo+x7G4V5tbrFRFOQa0RZnSJ6SCWs14GlLa/m/lxQ4PEDZD+bUDlWhLBjiqdmIpA==}
     dependencies:
-      '@walletconnect/core': 2.4.7
+      '@walletconnect/core': 2.4.8
       '@walletconnect/events': 1.0.1
       '@walletconnect/heartbeat': 1.2.0
       '@walletconnect/jsonrpc-provider': 1.0.6
       '@walletconnect/jsonrpc-utils': 1.0.4
       '@walletconnect/logger': 2.0.1
       '@walletconnect/time': 1.0.2
-      '@walletconnect/types': 2.4.7
-      '@walletconnect/utils': 2.4.7
+      '@walletconnect/types': 2.4.8
+      '@walletconnect/utils': 2.4.8
       events: 3.3.0
       pino: 7.11.0
     transitivePeerDependencies:
@@ -1963,8 +1963,8 @@ packages:
       - typescript
     dev: true
 
-  /@walletconnect/types/2.4.7:
-    resolution: {integrity: sha512-1VaPdPJrE+UrEjAhK5bdxq2+MTo3DvUMmQeNUsp3vUGhocQXB9hJQQ1rYBknYYSyDu2rTksGCQ4nv3ZOqfxvHw==}
+  /@walletconnect/types/2.4.8:
+    resolution: {integrity: sha512-NuL+c/BHExK7hwF+JoJVy/LnNB8sNtoxvlpIa2Er5qeB8MJsWtwbmEJMS/bP6CbOTSpO0kOpXGzb1ht0LD2rkw==}
     dependencies:
       '@walletconnect/events': 1.0.1
       '@walletconnect/heartbeat': 1.2.0
@@ -2007,17 +2007,17 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@walletconnect/universal-provider/2.4.7:
-    resolution: {integrity: sha512-xlefq2ahAsH3SpcsofWQQ5JT3Tz9NLAViA8FW07PHhfuf9p7OLp+Mu1wKxQEoBilyvfYRF4R5MTyTPy1wqJiRA==}
+  /@walletconnect/universal-provider/2.4.8:
+    resolution: {integrity: sha512-ZCISD6wMF2JDwyomc4ROpzGqe6mzRW7pWJ2fybqZWqKIWFaTC7HuE71cNQVmGB6/rlbyn0wvv6vXeEc1GewA8w==}
     dependencies:
       '@walletconnect/jsonrpc-http-connection': 1.0.4
       '@walletconnect/jsonrpc-provider': 1.0.6
       '@walletconnect/jsonrpc-types': 1.0.2
       '@walletconnect/jsonrpc-utils': 1.0.4
       '@walletconnect/logger': 2.0.1
-      '@walletconnect/sign-client': 2.4.7
-      '@walletconnect/types': 2.4.7
-      '@walletconnect/utils': 2.4.7
+      '@walletconnect/sign-client': 2.4.8
+      '@walletconnect/types': 2.4.8
+      '@walletconnect/utils': 2.4.8
       eip1193-provider: 1.0.1
       events: 3.3.0
       pino: 7.11.0
@@ -2072,8 +2072,8 @@ packages:
       - typescript
     dev: true
 
-  /@walletconnect/utils/2.4.7:
-    resolution: {integrity: sha512-t3kW0qLClnejTTKg3y/o/MmJb5ZDGfD13YT9Nw56Up3qq/pwVfTtWjt8vJOQWMIm0hZgjgESivcf6/wuu3/Oqw==}
+  /@walletconnect/utils/2.4.8:
+    resolution: {integrity: sha512-W/5Ly+p+6/RHsYzVUiuwxGK+J9BQEins0RRdPeO6tJjNPeR05SoJE564JSKRYxPkGf/9vB5wfOZ88IEzOIAYLw==}
     dependencies:
       '@stablelib/chacha20poly1305': 1.0.1
       '@stablelib/hkdf': 1.0.1
@@ -2084,7 +2084,7 @@ packages:
       '@walletconnect/relay-api': 1.0.9
       '@walletconnect/safe-json': 1.0.1
       '@walletconnect/time': 1.0.2
-      '@walletconnect/types': 2.4.7
+      '@walletconnect/types': 2.4.8
       '@walletconnect/window-getters': 1.0.1
       '@walletconnect/window-metadata': 1.0.1
       detect-browser: 5.3.0
@@ -2126,6 +2126,15 @@ packages:
       valtio: 1.9.0
     transitivePeerDependencies:
       - react
+    dev: true
+
+  /@web3modal/core/2.2.0:
+    resolution: {integrity: sha512-Kafg/KtK6S9x0Ofcaq9hj7dRK5/541nM+LnayPmHxx4fSrDgcM9YYhL12fI4BG1xGOJwkeZjgFOtS0qf123Cjw==}
+    dependencies:
+      buffer: 6.0.3
+      valtio: 1.9.0
+    transitivePeerDependencies:
+      - react
 
   /@web3modal/standalone/2.1.1:
     resolution: {integrity: sha512-K06VkZqltLIBKpnLeM2oszRDSdLnwXJWCcItWEOkH4LDFQIiq8lSeLhcamuadRxRKF4ZyTSLHHJ5MFcMfZEHQQ==}
@@ -2134,11 +2143,31 @@ packages:
       '@web3modal/ui': 2.1.1
     transitivePeerDependencies:
       - react
+    dev: true
+
+  /@web3modal/standalone/2.2.0:
+    resolution: {integrity: sha512-cLFW4VamSJ7L4sM5OGmr1SHK3FgyLUMEaacvHsCA3XSvUF0LxbMC+N4uBsONrW4c0JyIjTdeii1GqG4B3jwn7Q==}
+    dependencies:
+      '@web3modal/core': 2.2.0
+      '@web3modal/ui': 2.2.0
+    transitivePeerDependencies:
+      - react
 
   /@web3modal/ui/2.1.1:
     resolution: {integrity: sha512-0jRDxgPc/peaE5KgqnzzriXhdVu5xNyCMP5Enqdpd77VkknJIs7h16MYKidxgFexieyHpCOssWySsryWcP2sXA==}
     dependencies:
       '@web3modal/core': 2.1.1
+      lit: 2.6.1
+      motion: 10.15.5
+      qrcode: 1.5.1
+    transitivePeerDependencies:
+      - react
+    dev: true
+
+  /@web3modal/ui/2.2.0:
+    resolution: {integrity: sha512-jcV5C9AuMdsFdf6Ljsr0v2lInu8FJJyXcZPaMHkgYNIczzgMEpDE+UOA7hLnyCTUxM9R0AgRcgfTyMWb9H8Ssw==}
+    dependencies:
+      '@web3modal/core': 2.2.0
       lit: 2.6.1
       motion: 10.15.5
       qrcode: 1.5.1
@@ -4556,7 +4585,7 @@ packages:
       is-extglob: 2.1.1
 
   /is-hex-prefixed/1.0.0:
-    resolution: {integrity: sha1-fY035q135dEnFIkTxXPggtd39VQ=}
+    resolution: {integrity: sha512-WvtOiug1VFrE9v1Cydwm+FnXd3+w9GaeVUss5W4v/SLy3UW00vP+6iNF2SdnfiBoLy4bTqVdkftNGTUeOFVsbA==}
     engines: {node: '>=6.5.0', npm: '>=3'}
 
   /is-interactive/1.0.0:
@@ -6382,7 +6411,7 @@ packages:
     dev: true
 
   /strip-hex-prefix/1.0.0:
-    resolution: {integrity: sha1-DF8VX+8RUTczd96du1iNoFUA428=}
+    resolution: {integrity: sha512-q8d4ue7JGEiVcypji1bALTos+0pWtyGlivAWyPuTkHzuTCJqrK9sWxYQZUq6Nq3cuyv3bm734IhHvHtGGURU6A==}
     engines: {node: '>=6.5.0', npm: '>=3'}
     dependencies:
       is-hex-prefixed: 1.0.0


### PR DESCRIPTION
## Description

Updates `@walletconnect/ethereum-provider` to latest version that includes minor fixes, but more importantly uses more relaxed (`^...`) version for web3modal.

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/references/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: asimetriq.eth
