### PR TITLE
feat: add Status as injected connector name

### DIFF
--- a/packages/connectors/src/types.ts
+++ b/packages/connectors/src/types.ts
@@ -71,6 +71,7 @@ type InjectedProviderFlags = {
   isTrustWallet?: true
   isHyperPay?: true
   isXDEFI?: true
+  isStatus?: true
 }
 
 type InjectedProviders = InjectedProviderFlags & {

--- a/packages/connectors/src/utils/getInjectedName.ts
+++ b/packages/connectors/src/utils/getInjectedName.ts
@@ -29,6 +29,7 @@ export function getInjectedName(ethereum?: Ethereum) {
     if (provider.isHyperPay) return 'HyperPay Wallet'
     if (provider.isMetaMask) return 'MetaMask'
     if (provider.isXDEFI) return 'XDEFI Wallet'
+    if (provider.isStatus) return 'Status'
   }
 
   // Some injected providers detect multiple other providers and create a list at `ethers.providers`


### PR DESCRIPTION
## Description

Sets the "Status" name for the wallet injected by the [Status App](https://status.im/get/).

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/references/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: filoozom.eth