### PR TITLE
Add isDawn flag to `InjectedProviderFlags`

### DIFF
--- a/.changeset/ninety-needles-greet.md
+++ b/.changeset/ninety-needles-greet.md
@@ -1,0 +1,5 @@
+---
+'@wagmi/connectors': patch
+---
+
+Add isDawn wallet flag

--- a/.changeset/ninety-needles-greet.md
+++ b/.changeset/ninety-needles-greet.md
@@ -2,4 +2,4 @@
 '@wagmi/connectors': patch
 ---
 
-Add isDawn wallet flag
+Added Dawn wallet flag

--- a/packages/connectors/src/types.ts
+++ b/packages/connectors/src/types.ts
@@ -52,6 +52,7 @@ type InjectedProviderFlags = {
   isBitski?: true
   isBraveWallet?: true
   isCoinbaseWallet?: true
+  isDawn?: true
   isExodus?: true
   isFrame?: true
   isFrontier?: true

--- a/packages/connectors/src/utils/getInjectedName.test.ts
+++ b/packages/connectors/src/utils/getInjectedName.test.ts
@@ -24,6 +24,7 @@ describe.each([
     expected: 'Brave Wallet',
   },
   { ethereum: { isCoinbaseWallet: true }, expected: 'Coinbase Wallet' },
+  { ethereum: { isDawn: true }, expected: 'Dawn Wallet' },
   { ethereum: { isExodus: true }, expected: 'Exodus' },
   { ethereum: { isFrame: true }, expected: 'Frame' },
   { ethereum: { isFrontier: true }, expected: 'Frontier Wallet' },

--- a/packages/connectors/src/utils/getInjectedName.ts
+++ b/packages/connectors/src/utils/getInjectedName.ts
@@ -11,6 +11,7 @@ export function getInjectedName(ethereum?: Ethereum) {
     if (provider.isBitski) return 'Bitski'
     if (provider.isBraveWallet) return 'Brave Wallet'
     if (provider.isCoinbaseWallet) return 'Coinbase Wallet'
+    if (provider.isDawn) return 'Dawn Wallet'
     if (provider.isExodus) return 'Exodus'
     if (provider.isFrame) return 'Frame'
     if (provider.isFrontier) return 'Frontier Wallet'


### PR DESCRIPTION
## Description
Dawn Wallet is an iOS based Ethereum wallet with a native Safari extension: https://twitter.com/dawn_wallet. 

We are integrating into ConnectKit - ConnectKit uses the `Ethereum` type from wagmi, which itself uses the `InjectedProviderFlags` type to recognise injected wallets. 

We need the `isDawn` flag to be available on the `Ethereum` type in ConnectKit (see this PR: https://github.com/family/connectkit/pull/162). This PR in wagmi adds it.

Your ENS/address: tomwaite.eth
