### PR TITLE
feat: Updated Polygon zkEVM Testnet Chain Id

### DIFF
--- a/.changeset/cold-grapes-try.md
+++ b/.changeset/cold-grapes-try.md
@@ -1,0 +1,5 @@
+---
+'@wagmi/chains': patch
+---
+
+Updated Polygon zkEVM Testnet Chain ID

--- a/packages/chains/src/polygonZkEvmTestnet.ts
+++ b/packages/chains/src/polygonZkEvmTestnet.ts
@@ -1,7 +1,7 @@
 import { Chain } from './types'
 
 export const polygonZkEvmTestnet = {
-  id: 1422,
+  id: 1442,
   name: 'Polygon zkEVM Testnet',
   network: 'polygon-zkevm-testnet',
   nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },


### PR DESCRIPTION
## Description

Updated the chain id as per the official docs from 1422 to 1442
https://wiki.polygon.technology/docs/zkEVM/develop#connecting-to-zkevm

BREAKING CHANGE: N

## Additional Information

- [X] I read the [contributing docs](/wagmi-dev/references/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address:

codingwithmanny.eth
