### PR TITLE
Update BSC testnet RPC URL

### DIFF
--- a/packages/chains/src/bscTestnet.ts
+++ b/packages/chains/src/bscTestnet.ts
@@ -10,8 +10,8 @@ export const bscTestnet = {
     symbol: 'tBNB',
   },
   rpcUrls: {
-    default: { http: ['https://bsc-testnet.public.blastapi.io'] },
-    public: { http: ['https://bsc-testnet.public.blastapi.io'] },
+    default: { http: ['https://data-seed-prebsc-1-s1.binance.org:8545'] },
+    public: { http: ['https://data-seed-prebsc-1-s1.binance.org:8545'] },
   },
   blockExplorers: {
     etherscan: { name: 'BscScan', url: 'https://testnet.bscscan.com' },


### PR DESCRIPTION
## Description

Update bscTestnet.ts file in the wagmi/chains/bscTestnet.ts repository with the latest RPC URL to replace the expired one

## Additional Information

Replace with the bscTest Rpc in the official documentation.(https://docs.bscscan.com/v/bscscan-testnet)

My ENS/address: 0xF703A4ADeD9797587e795eE12862dc3Bab7F8146
