### PR TITLE
Add injected name mapping for GameStop Wallet

### DIFF
--- a/.changeset/three-wombats-serve.md
+++ b/.changeset/three-wombats-serve.md
@@ -1,5 +1,5 @@
 ---
-'@wagmi/connectors': minor
+'@wagmi/connectors': patch
 ---
 
 Added GameStop Wallet to injected connector flags

--- a/.changeset/three-wombats-serve.md
+++ b/.changeset/three-wombats-serve.md
@@ -1,0 +1,5 @@
+---
+'@wagmi/connectors': minor
+---
+
+Added GameStop Wallet to injected connector flags

--- a/packages/connectors/src/types.ts
+++ b/packages/connectors/src/types.ts
@@ -57,6 +57,7 @@ type InjectedProviderFlags = {
   isExodus?: true
   isFrame?: true
   isFrontier?: true
+  isGamestop?: true
   isKuCoinWallet?: true
   isMathWallet?: true
   isMetaMask?: true

--- a/packages/connectors/src/utils/getInjectedName.test.ts
+++ b/packages/connectors/src/utils/getInjectedName.test.ts
@@ -29,6 +29,7 @@ describe.each([
   { ethereum: { isExodus: true }, expected: 'Exodus' },
   { ethereum: { isFrame: true }, expected: 'Frame' },
   { ethereum: { isFrontier: true }, expected: 'Frontier Wallet' },
+  { ethereum: { isGamestop: true }, expected: 'GameStop Wallet' },
   { ethereum: { isKuCoinWallet: true }, expected: 'KuCoin Wallet' },
   {
     ethereum: { isKuCoinWallet: true, isMetaMask: true },

--- a/packages/connectors/src/utils/getInjectedName.ts
+++ b/packages/connectors/src/utils/getInjectedName.ts
@@ -16,6 +16,7 @@ export function getInjectedName(ethereum?: Ethereum) {
     if (provider.isExodus) return 'Exodus'
     if (provider.isFrame) return 'Frame'
     if (provider.isFrontier) return 'Frontier Wallet'
+    if (provider.isGamestop) return 'GameStop Wallet'
     if (provider.isKuCoinWallet) return 'KuCoin Wallet'
     if (provider.isMathWallet) return 'MathWallet'
     if (provider.isOneInchIOSWallet || provider.isOneInchAndroidWallet)


### PR DESCRIPTION
## Description

Added a 'injected wallet' name resolution for the GameStop Wallet.

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/references/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address:
0x1337CC354AeAf15B0E98A609cd348DF171174e14