### PR TITLE
Fix isTally injector name

### DIFF
--- a/.changeset/breezy-files-dance.md
+++ b/.changeset/breezy-files-dance.md
@@ -1,0 +1,5 @@
+---
+'@wagmi/connectors': patch
+---
+
+Renamed `isTally` injected provider to `Taho`

--- a/packages/connectors/src/utils/getInjectedName.test.ts
+++ b/packages/connectors/src/utils/getInjectedName.test.ts
@@ -47,7 +47,7 @@ describe.each([
   { ethereum: { isPortal: true }, expected: 'Ripio Portal' },
   { ethereum: { isRainbow: true }, expected: 'Rainbow' },
   { ethereum: { isStatus: true }, expected: 'Status' },
-  { ethereum: { isTally: true }, expected: 'Tally' },
+  { ethereum: { isTally: true }, expected: 'Taho' },
   {
     ethereum: { isTokenPocket: true, isMetaMask: true },
     expected: 'TokenPocket',

--- a/packages/connectors/src/utils/getInjectedName.ts
+++ b/packages/connectors/src/utils/getInjectedName.ts
@@ -28,7 +28,7 @@ export function getInjectedName(ethereum?: Ethereum) {
     if (provider.isPortal) return 'Ripio Portal'
     if (provider.isRainbow) return 'Rainbow'
     if (provider.isStatus) return 'Status'
-    if (provider.isTally) return 'Tally'
+    if (provider.isTally) return 'Taho'
     if (provider.isTokenPocket) return 'TokenPocket'
     if (provider.isTokenary) return 'Tokenary'
     if (provider.isTrust || provider.isTrustWallet) return 'Trust Wallet'


### PR DESCRIPTION
## Description
- Renamed `isTally` injected provider to `Taho`

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/references/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)
