### PR TITLE
feat(chains): add websocket RPC to foundry chain

### DIFF
--- a/packages/chains/src/foundry.ts
+++ b/packages/chains/src/foundry.ts
@@ -10,7 +10,13 @@ export const foundry = {
     symbol: 'ETH',
   },
   rpcUrls: {
-    default: { http: ['http://127.0.0.1:8545'] },
-    public: { http: ['http://127.0.0.1:8545'] },
+    default: {
+      http: ['http://127.0.0.1:8545'],
+      webSocket: ['ws://127.0.0.1:8545'],
+    },
+    public: {
+      http: ['http://127.0.0.1:8545'],
+      webSocket: ['ws://127.0.0.1:8545'],
+    },
   },
 } as const satisfies Chain


### PR DESCRIPTION

## Description

Foundry/Anvil supports websockets out of the box: https://book.getfoundry.sh/reference/anvil/#supported-transport-layers


## Additional Information

- [ ] I read the [contributing docs](/wagmi-dev/references/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: frolic.eth
