### PR TITLE
feat(connectors): add isRabby to provider flags

### DIFF
--- a/.changeset/pretty-readers-wonder.md
+++ b/.changeset/pretty-readers-wonder.md
@@ -1,0 +1,5 @@
+---
+'@wagmi/connectors': patch
+---
+
+Add isRabby to detect rabby wallet

--- a/.changeset/pretty-readers-wonder.md
+++ b/.changeset/pretty-readers-wonder.md
@@ -2,4 +2,4 @@
 '@wagmi/connectors': patch
 ---
 
-Add isRabby to detect rabby wallet
+Added Rabby to injected connector flags

--- a/packages/connectors/src/types.ts
+++ b/packages/connectors/src/types.ts
@@ -69,6 +69,7 @@ type InjectedProviderFlags = {
   isOpera?: true
   isPhantom?: true
   isPortal?: true
+  isRabby?: true
   isRainbow?: true
   isStatus?: true
   isTally?: true

--- a/packages/connectors/src/utils/getInjectedName.test.ts
+++ b/packages/connectors/src/utils/getInjectedName.test.ts
@@ -45,6 +45,7 @@ describe.each([
   { ethereum: { isPhantom: true }, expected: 'Phantom' },
   { ethereum: { isPhantom: true, isMetaMask: true }, expected: 'Phantom' },
   { ethereum: { isPortal: true }, expected: 'Ripio Portal' },
+  { ethereum: { isRabby: true }, expected: 'Rabby' },
   { ethereum: { isRainbow: true }, expected: 'Rainbow' },
   { ethereum: { isStatus: true }, expected: 'Status' },
   { ethereum: { isTally: true }, expected: 'Tally' },

--- a/packages/connectors/src/utils/getInjectedName.ts
+++ b/packages/connectors/src/utils/getInjectedName.ts
@@ -26,6 +26,7 @@ export function getInjectedName(ethereum?: Ethereum) {
     if (provider.isOpera) return 'Opera'
     if (provider.isPhantom) return 'Phantom'
     if (provider.isPortal) return 'Ripio Portal'
+    if (provider.isRabby) return 'Rabby'
     if (provider.isRainbow) return 'Rainbow'
     if (provider.isStatus) return 'Status'
     if (provider.isTally) return 'Tally'


### PR DESCRIPTION
## Description

Adds the isRabby provider flag when using the Rabby (https://rabby.io/) extenstion.

## Additional Information

- [X] I read the [contributing docs](/wagmi-dev/references/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: fiboape.eth
