### PR TITLE
fix remove tokenpocket wallet login limit

### DIFF
--- a/packages/connectors/src/metaMask.ts
+++ b/packages/connectors/src/metaMask.ts
@@ -51,7 +51,6 @@ export class MetaMaskConnector extends InjectedConnector {
           if (ethereum.isAvalanche) return
           if (ethereum.isKuCoinWallet) return
           if (ethereum.isPortal) return
-          if (ethereum.isTokenPocket) return
           if (ethereum.isTokenary) return
           return ethereum
         }


### PR DESCRIPTION
## Description

Remove TokenPocket's limitation, as every injected wallet has implemented the same interface, it's not fair just to add some of them. And most dapp only add metamask's provider, which causes the dapp cannot log in with our wallet.

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/references/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address:
tonychen.eth
