### PR TITLE
Updated Linea Testnet chain config

### DIFF
--- a/packages/chains/src/lineaTestnet.ts
+++ b/packages/chains/src/lineaTestnet.ts
@@ -1,24 +1,32 @@
 import { Chain } from './types'
 
-export const lineaTestnet = {
+export const lineaGoerli = {
   id: 59140,
-  name: 'Linea Testnet',
+  name: 'Linea Goerli Testnet',
   network: 'linea-testnet',
-  nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
+  nativeCurrency: { name: 'Linea Goerli Ether', symbol: 'ETH', decimals: 18 },
   rpcUrls: {
+    infura: {
+      http: ['https://consensys-zkevm-goerli-prealpha.infura.io/v3/'],
+      webSocket: ['wss://consensys-zkevm-goerli-prealpha.infura.io/ws/v3/'],
+    },
     default: {
       http: ['https://rpc.goerli.linea.build'],
-      webSocket: ['wss://rpc.goerli.linea.build'],
     },
     public: {
       http: ['https://rpc.goerli.linea.build'],
-      webSocket: ['wss://rpc.goerli.linea.build'],
     },
   },
   blockExplorers: {
     default: {
-      name: 'BlockScout',
+      name: 'Blockscout',
       url: 'https://explorer.goerli.linea.build',
+    },
+  },
+  contracts: {
+    multicall3: {
+      address: '0xca11bde05977b3631167028862be2a173976ca11',
+      blockCreated: 498623,
     },
   },
   testnet: true,

--- a/packages/chains/src/lineaTestnet.ts
+++ b/packages/chains/src/lineaTestnet.ts
@@ -1,6 +1,6 @@
 import { Chain } from './types'
 
-export const lineaGoerli = {
+export const lineaTestnet = {
   id: 59140,
   name: 'Linea Goerli Testnet',
   network: 'linea-testnet',
@@ -8,18 +8,20 @@ export const lineaGoerli = {
   rpcUrls: {
     infura: {
       http: ['https://consensys-zkevm-goerli-prealpha.infura.io/v3/'],
-      webSocket: ['wss://consensys-zkevm-goerli-prealpha.infura.io/ws/v3/'],
+      webSocket: ['wss://consensys-zkevm-goerli-prealpha.infura.io/ws/v3/']
     },
     default: {
       http: ['https://rpc.goerli.linea.build'],
+      webSocket: ['wss://rpc.goerli.linea.build']
     },
     public: {
       http: ['https://rpc.goerli.linea.build'],
+      webSocket: ['wss://rpc.goerli.linea.build']
     },
   },
   blockExplorers: {
     default: {
-      name: 'Blockscout',
+      name: 'BlockScout',
       url: 'https://explorer.goerli.linea.build',
     },
   },


### PR DESCRIPTION
## Description

Added rpcUrls.infura
Added contracts.multicall3

## Additional Information
The public endpoint is rate limited to 20req/sec based on source IP. If dApps rely on it, they can get 429s. In such a case better to switch over Infura provider

ENS/address: @croll83.eth
