### PR TITLE
Update: Kucoin Wallet upgrade to Halo Wallet

### DIFF
--- a/.changeset/ninety-impalas-rest.md
+++ b/.changeset/ninety-impalas-rest.md
@@ -1,0 +1,5 @@
+---
+'@wagmi/connectors': major
+---
+
+Update: Kucoin Wallet upgrade to Halo Wallet

--- a/.changeset/ninety-impalas-rest.md
+++ b/.changeset/ninety-impalas-rest.md
@@ -1,5 +1,5 @@
 ---
-'@wagmi/connectors': major
+'@wagmi/connectors': patch
 ---
 
 Update: Kucoin Wallet upgrade to Halo Wallet

--- a/.changeset/ninety-impalas-rest.md
+++ b/.changeset/ninety-impalas-rest.md
@@ -2,4 +2,4 @@
 '@wagmi/connectors': patch
 ---
 
-Update: Kucoin Wallet upgrade to Halo Wallet
+Changed Kucoin Wallet name mapping to Halo Wallet

--- a/packages/connectors/src/metaMask.ts
+++ b/packages/connectors/src/metaMask.ts
@@ -51,7 +51,6 @@ export class MetaMaskConnector extends InjectedConnector {
           if (ethereum.isAvalanche) return
           if (ethereum.isBitKeep) return
           if (ethereum.isBlockWallet) return
-          if (ethereum.isKuCoinWallet) return
           if (ethereum.isMathWallet) return
           if (ethereum.isOkxWallet || ethereum.isOKExWallet) return
           if (ethereum.isOneInchIOSWallet || ethereum.isOneInchAndroidWallet)

--- a/packages/connectors/src/types.ts
+++ b/packages/connectors/src/types.ts
@@ -82,6 +82,7 @@ type InjectedProviderFlags = {
   isTrustWallet?: true
   isXDEFI?: true
   isZerion?: true
+  isHaloWallet?: true
 }
 
 type InjectedProviders = InjectedProviderFlags & {

--- a/packages/connectors/src/utils/getInjectedName.test.ts
+++ b/packages/connectors/src/utils/getInjectedName.test.ts
@@ -34,11 +34,11 @@ describe.each([
   { ethereum: { isGamestop: true }, expected: 'GameStop Wallet' },
   { ethereum: { isHyperPay: true }, expected: 'HyperPay Wallet' },
   { ethereum: { isImToken: true }, expected: 'ImToken' },
-  { ethereum: { isHaloWallet: true }, expected: 'Halo Wallet' },
   {
-    ethereum: { isHaloWallet: true, isKuCoinWallet: true, isMetaMask: true },
+    ethereum: { isHaloWallet: true },
     expected: 'Halo Wallet',
   },
+  { ethereum: { isKuCoinWallet: true }, expected: 'KuCoin Wallet' },
   {
     ethereum: { isMathWallet: true, isMetaMask: true },
     expected: 'MathWallet',

--- a/packages/connectors/src/utils/getInjectedName.test.ts
+++ b/packages/connectors/src/utils/getInjectedName.test.ts
@@ -34,10 +34,10 @@ describe.each([
   { ethereum: { isGamestop: true }, expected: 'GameStop Wallet' },
   { ethereum: { isHyperPay: true }, expected: 'HyperPay Wallet' },
   { ethereum: { isImToken: true }, expected: 'ImToken' },
-  { ethereum: { isKuCoinWallet: true }, expected: 'KuCoin Wallet' },
+  { ethereum: { isHaloWallet: true }, expected: 'Halo Wallet' },
   {
-    ethereum: { isKuCoinWallet: true, isMetaMask: true },
-    expected: 'KuCoin Wallet',
+    ethereum: { isHaloWallet: true, isKuCoinWallet: true, isMetaMask: true },
+    expected: 'Halo Wallet',
   },
   {
     ethereum: { isMathWallet: true, isMetaMask: true },

--- a/packages/connectors/src/utils/getInjectedName.ts
+++ b/packages/connectors/src/utils/getInjectedName.ts
@@ -22,6 +22,7 @@ export function getInjectedName(ethereum?: Ethereum) {
     if (provider.isHyperPay) return 'HyperPay Wallet'
     if (provider.isImToken) return 'ImToken'
     if (provider.isHaloWallet) return 'Halo Wallet'
+    if (provider.isKuCoinWallet) return 'KuCoin Wallet'
     if (provider.isMathWallet) return 'MathWallet'
     if (provider.isOkxWallet || provider.isOKExWallet) return 'OKX Wallet'
     if (provider.isOneInchIOSWallet || provider.isOneInchAndroidWallet)

--- a/packages/connectors/src/utils/getInjectedName.ts
+++ b/packages/connectors/src/utils/getInjectedName.ts
@@ -21,7 +21,7 @@ export function getInjectedName(ethereum?: Ethereum) {
     if (provider.isGamestop) return 'GameStop Wallet'
     if (provider.isHyperPay) return 'HyperPay Wallet'
     if (provider.isImToken) return 'ImToken'
-    if (provider.isKuCoinWallet) return 'KuCoin Wallet'
+    if (provider.isHaloWallet) return 'Halo Wallet'
     if (provider.isMathWallet) return 'MathWallet'
     if (provider.isOkxWallet || provider.isOKExWallet) return 'OKX Wallet'
     if (provider.isOneInchIOSWallet || provider.isOneInchAndroidWallet)


### PR DESCRIPTION
## Description
  
As KuCoin Wallet rebranded to Halo Wallet, the keyword needs to be updated to isHaloWallet.

The official website of KuCoin Wallet is https://www.kuwallet.com/, which has been redirected to https://halo.social/ - the official website of Halo Wallet.

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/references/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address:
