### PR TITLE
Add Multicall3 address to zkSync and zkSynTestnet

### DIFF
--- a/.changeset/hungry-toes-exist.md
+++ b/.changeset/hungry-toes-exist.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/chains": patch
+---
+
+Added multicall3 address to zkSync and zkSyncTestnet

--- a/packages/chains/src/zkSync.ts
+++ b/packages/chains/src/zkSync.ts
@@ -25,4 +25,9 @@ export const zkSync = {
       url: 'https://explorer.zksync.io',
     },
   },
+  contracts: {
+    multicall3: {
+      address: '0x47898B2C52C957663aE9AB46922dCec150a2272c',
+    },
+  },
 } as const satisfies Chain

--- a/packages/chains/src/zkSyncTestnet.ts
+++ b/packages/chains/src/zkSyncTestnet.ts
@@ -21,5 +21,10 @@ export const zkSyncTestnet = {
       url: 'https://goerli.explorer.zksync.io',
     },
   },
+  contracts: {
+    multicall3: {
+      address: '0x89e4EDbEC85362a285d7a1D5D255ccD2b8106be2',
+    },
+  },
   testnet: true,
 } as const satisfies Chain


### PR DESCRIPTION
## Description

Added Multicall3 addresses to zkSync and zkSyncTestnet.

Since it is not yet possible to deploy Multicall3 with canonical address to zkSync, community deployed Multicall3 addresses are added. For more reference see https://github.com/mds1/multicall/issues/76

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/references/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)
