### PR TITLE
Removes pulsechain mainnet subdomain

### DIFF
--- a/.changeset/sweet-kings-kiss.md
+++ b/.changeset/sweet-kings-kiss.md
@@ -1,0 +1,5 @@
+---
+'@wagmi/chains': patch
+---
+
+Removes mainnet subdomain from pulsechain chain id 369

--- a/packages/chains/src/pulsechain.ts
+++ b/packages/chains/src/pulsechain.ts
@@ -7,12 +7,12 @@ export const pulsechain = {
   nativeCurrency: { name: 'Pulse', symbol: 'PLS', decimals: 18 },
   rpcUrls: {
     default: {
-      http: ['https://rpc.mainnet.pulsechain.com'],
-      webSocket: ['wss://ws.mainnet.pulsechain.com'],
+      http: ['https://rpc.pulsechain.com'],
+      webSocket: ['wss://ws.pulsechain.com'],
     },
     public: {
-      http: ['https://rpc.mainnet.pulsechain.com'],
-      webSocket: ['wss://ws.mainnet.pulsechain.com'],
+      http: ['https://rpc.pulsechain.com'],
+      webSocket: ['wss://ws.pulsechain.com'],
     },
   },
   blockExplorers: {


### PR DESCRIPTION
## Description

Removes `mainnet` subdomain from pulsechain rpc endpoints

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/references/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address:
