### PR TITLE
feat(connectors): add isDefiant to provider flags

### DIFF
--- a/.changeset/great-swans-tie.md
+++ b/.changeset/great-swans-tie.md
@@ -1,0 +1,5 @@
+---
+'@wagmi/connectors': patch
+---
+
+Added Defiant to injected connector flags

--- a/packages/connectors/src/metaMask.ts
+++ b/packages/connectors/src/metaMask.ts
@@ -58,6 +58,7 @@ export class MetaMaskConnector extends InjectedConnector {
           if (ethereum.isOpera) return
           if (ethereum.isPortal) return
           if (ethereum.isRabby) return
+          if (ethereum.isDefiant) return
           if (ethereum.isTokenPocket) return
           if (ethereum.isTokenary) return
           if (ethereum.isZerion) return

--- a/packages/connectors/src/types.ts
+++ b/packages/connectors/src/types.ts
@@ -19,6 +19,7 @@ type InjectedProviderFlags = {
   isBraveWallet?: true
   isCoinbaseWallet?: true
   isDawn?: true
+  isDefiant?: true
   isEnkrypt?: true
   isExodus?: true
   isFrame?: true

--- a/packages/connectors/src/utils/getInjectedName.test.ts
+++ b/packages/connectors/src/utils/getInjectedName.test.ts
@@ -27,6 +27,7 @@ describe.each([
   },
   { ethereum: { isCoinbaseWallet: true }, expected: 'Coinbase Wallet' },
   { ethereum: { isDawn: true }, expected: 'Dawn Wallet' },
+  { ethereum: { isDefiant: true }, expected: 'Defiant' },
   { ethereum: { isEnkrypt: true }, expected: 'Enkrypt' },
   { ethereum: { isExodus: true }, expected: 'Exodus' },
   { ethereum: { isFrame: true }, expected: 'Frame' },

--- a/packages/connectors/src/utils/getInjectedName.ts
+++ b/packages/connectors/src/utils/getInjectedName.ts
@@ -14,6 +14,7 @@ export function getInjectedName(ethereum?: WindowProvider) {
     if (provider.isBraveWallet) return 'Brave Wallet'
     if (provider.isCoinbaseWallet) return 'Coinbase Wallet'
     if (provider.isDawn) return 'Dawn Wallet'
+    if (provider.isDefiant) return 'Defiant'
     if (provider.isEnkrypt) return 'Enkrypt'
     if (provider.isExodus) return 'Exodus'
     if (provider.isFrame) return 'Frame'


### PR DESCRIPTION
## Description

Adds the isDefiant provider flag when using the Defiant (https://defiantapp.tech/) mobile wallet.

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/references/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: ivancito.eth
