### PR TITLE
feat: add Talisman wallet flag

### DIFF
--- a/.changeset/mighty-squids-hug.md
+++ b/.changeset/mighty-squids-hug.md
@@ -1,0 +1,5 @@
+---
+'@wagmi/connectors': patch
+---
+
+Added Talisman wallet flag

--- a/packages/connectors/src/types.ts
+++ b/packages/connectors/src/types.ts
@@ -40,6 +40,7 @@ type InjectedProviderFlags = {
   isRabby?: true
   isRainbow?: true
   isStatus?: true
+  isTalisman?: true
   isTally?: true
   isTokenPocket?: true
   isTokenary?: true

--- a/packages/connectors/src/utils/getInjectedName.test.ts
+++ b/packages/connectors/src/utils/getInjectedName.test.ts
@@ -52,6 +52,7 @@ describe.each([
   { ethereum: { isRabby: true }, expected: 'Rabby' },
   { ethereum: { isRainbow: true }, expected: 'Rainbow' },
   { ethereum: { isStatus: true }, expected: 'Status' },
+  { ethereum: { isTalisman: true }, expected: 'Talisman' },
   { ethereum: { isTally: true }, expected: 'Taho' },
   {
     ethereum: { isTokenPocket: true, isMetaMask: true },

--- a/packages/connectors/src/utils/getInjectedName.ts
+++ b/packages/connectors/src/utils/getInjectedName.ts
@@ -34,6 +34,7 @@ export function getInjectedName(ethereum?: WindowProvider) {
     if (provider.isRabby) return 'Rabby'
     if (provider.isRainbow) return 'Rainbow'
     if (provider.isStatus) return 'Status'
+    if (provider.isTalisman) return 'Talisman'
     if (provider.isTally) return 'Taho'
     if (provider.isTokenPocket) return 'TokenPocket'
     if (provider.isTokenary) return 'Tokenary'


### PR DESCRIPTION
## Description

Adds `isTalisman` flag to `InjectedProviderFlags` for [Talisman](https://talisman.xyz)  browser extension wallet.
Objective is to allow Talisman to be integrated with RainbowKit, which uses Wagmi `InjectedProviderFlags` type. 

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/references/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: 0xkheops.eth
