### PR TITLE
chore: update zksync multicall addresses

### DIFF
--- a/.changeset/rich-bugs-begin.md
+++ b/.changeset/rich-bugs-begin.md
@@ -1,0 +1,5 @@
+---
+'@wagmi/chains': patch
+---
+
+Updated multicall3 address for zkSync and zkSyncTestnet

--- a/packages/chains/src/zkSync.ts
+++ b/packages/chains/src/zkSync.ts
@@ -27,7 +27,7 @@ export const zkSync = {
   },
   contracts: {
     multicall3: {
-      address: '0x47898B2C52C957663aE9AB46922dCec150a2272c',
+      address: '0xF9cda624FBC7e059355ce98a31693d299FACd963',
     },
   },
 } as const satisfies Chain

--- a/packages/chains/src/zkSyncTestnet.ts
+++ b/packages/chains/src/zkSyncTestnet.ts
@@ -23,7 +23,7 @@ export const zkSyncTestnet = {
   },
   contracts: {
     multicall3: {
-      address: '0x89e4EDbEC85362a285d7a1D5D255ccD2b8106be2',
+      address: '0xF9cda624FBC7e059355ce98a31693d299FACd963',
     },
   },
   testnet: true,


### PR DESCRIPTION
## Description

Details in https://github.com/wagmi-dev/references/discussions/296. This updates the Multicall3 addresses for zkSync Era and the ZkSync Era Goerli Testnet

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/references/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: `msolomon.eth`
