### PR TITLE
chore: update universalresolver addresses

### DIFF
--- a/.changeset/afraid-feet-compare.md
+++ b/.changeset/afraid-feet-compare.md
@@ -1,0 +1,5 @@
+---
+'@wagmi/chains': minor
+---
+
+Updated UniversalResolver addresses to latest version

--- a/packages/chains/src/goerli.ts
+++ b/packages/chains/src/goerli.ts
@@ -36,8 +36,8 @@ export const goerli = {
       address: '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e',
     },
     ensUniversalResolver: {
-      address: '0xA292E2E58d4ddEb29C33c63173d0E8B7a2A4c62e',
-      blockCreated: 8610406,
+      address: '0x56522D00C410a43BFfDF00a9A569489297385790',
+      blockCreated: 8765204,
     },
     multicall3: {
       address: '0xca11bde05977b3631167028862be2a173976ca11',

--- a/packages/chains/src/mainnet.ts
+++ b/packages/chains/src/mainnet.ts
@@ -36,8 +36,8 @@ export const mainnet = {
       address: '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e',
     },
     ensUniversalResolver: {
-      address: '0xE4Acdd618deED4e6d2f03b9bf62dc6118FC9A4da',
-      blockCreated: 16773775,
+      address: '0xc0497E381f536Be9ce14B0dD3817cBcAe57d2F62',
+      blockCreated: 16966585,
     },
     multicall3: {
       address: '0xca11bde05977b3631167028862be2a173976ca11',


### PR DESCRIPTION
## Description

Changed UniversalResolver addresses to latest deployments of each. The new UniversalResolver version is backwards-compatible with code written for previous versions.

## Additional Information

-  [x] I read the [contributing docs](/wagmi-dev/references/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: taytems.eth
