### PR TITLE
fix: add multicall3 for canto

### DIFF
--- a/.changeset/little-buses-cross.md
+++ b/.changeset/little-buses-cross.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/chains": patch
+---
+
+Added multicall3 for canto

--- a/packages/chains/src/canto.ts
+++ b/packages/chains/src/canto.ts
@@ -19,4 +19,10 @@ export const canto = {
       url: 'https://evm.explorer.canto.io',
     },
   },
+  contracts: {
+    multicall3: {
+      address: '0xca11bde05977b3631167028862be2a173976ca11',
+      blockCreated: 2905789,
+    },
+  },
 } as const satisfies Chain


### PR DESCRIPTION
## Description

Add multicall3 for canto.

<img width="510" alt="" src="https://github.com/wagmi-dev/references/assets/126733611/fd013911-f989-4db9-8ead-f51dddd4c778">

https://evm.explorer.canto.io/tx/0x9893d3c1ab4c34c6e7fd71ed692ec845c66cce232a1fbcf5d6ecc16a7005e91c

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/references/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address:
