### PR TITLE
chore: update README.md to include baseGoerli

### DIFF
--- a/packages/chains/README.md
+++ b/packages/chains/README.md
@@ -35,6 +35,7 @@ const { chains, provider } = configureChains(
 - `auroraTestnet`
 - `avalanche`
 - `avalancheFuji`
+- `baseGoerli`
 - `bronos`
 - `bronosTestnet`
 - `bsc`


### PR DESCRIPTION
## Description

Updated the Readme to explicitly indicate that `baseGoerli` [is supported](https://github.com/wagmi-dev/references/blob/main/packages/chains/src/baseGoerli.ts
) by WAGMI. Up until now this was not the case, and could be confusing to new developers.


## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/references/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: deepcryptodive.eth
