### PR TITLE
feat: add Nova Wallet flag

### DIFF
--- a/.changeset/stupid-hotels-impress.md
+++ b/.changeset/stupid-hotels-impress.md
@@ -2,4 +2,4 @@
 "@wagmi/connectors": patch
 ---
 
-Added Nova Wallet flag
+Added `isNovaWallet` injected flag.

--- a/.changeset/stupid-hotels-impress.md
+++ b/.changeset/stupid-hotels-impress.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/connectors": patch
+---
+
+Added Nova Wallet flag

--- a/packages/connectors/src/types.ts
+++ b/packages/connectors/src/types.ts
@@ -30,6 +30,7 @@ type InjectedProviderFlags = {
   isKuCoinWallet?: true
   isMathWallet?: true
   isMetaMask?: true
+  isNovaWallet?: true
   isOkxWallet?: true
   isOKExWallet?: true
   isOneInchAndroidWallet?: true

--- a/packages/connectors/src/utils/getInjectedName.test.ts
+++ b/packages/connectors/src/utils/getInjectedName.test.ts
@@ -44,6 +44,7 @@ describe.each([
     ethereum: { isMathWallet: true, isMetaMask: true },
     expected: 'MathWallet',
   },
+  { ethereum: { isNovaWallet: true }, expected: 'Nova Wallet' },
   { ethereum: { isOneInchIOSWallet: true }, expected: '1inch Wallet' },
   { ethereum: { isOneInchAndroidWallet: true }, expected: '1inch Wallet' },
   { ethereum: { isPhantom: true }, expected: 'Phantom' },

--- a/packages/connectors/src/utils/getInjectedName.ts
+++ b/packages/connectors/src/utils/getInjectedName.ts
@@ -25,6 +25,7 @@ export function getInjectedName(ethereum?: WindowProvider) {
     if (provider.isHaloWallet) return 'Halo Wallet'
     if (provider.isKuCoinWallet) return 'KuCoin Wallet'
     if (provider.isMathWallet) return 'MathWallet'
+    if (provider.isNovaWallet) return 'Nova Wallet'
     if (provider.isOkxWallet || provider.isOKExWallet) return 'OKX Wallet'
     if (provider.isOneInchIOSWallet || provider.isOneInchAndroidWallet)
       return '1inch Wallet'


### PR DESCRIPTION
## Description

Adds `isNovaWallet` flag to InjectedProviderFlags for [Nova Wallet](https://novawallet.io) mobile wallet.

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/references/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address:
