### PR TITLE
fix: throw ResourceUnavailableRpcError when error code -32002

### DIFF
--- a/packages/connectors/src/injected.ts
+++ b/packages/connectors/src/injected.ts
@@ -2,7 +2,7 @@ import type { Chain } from '@wagmi/chains'
 import type { Address } from 'abitype'
 import {
   ProviderRpcError,
-  ResourceNotFoundRpcError,
+  ResourceUnavailableRpcError,
   SwitchChainError,
   UserRejectedRequestError,
   createWalletClient,
@@ -123,7 +123,7 @@ export class InjectedConnector extends Connector<
       if (this.isUserRejectedRequestError(error))
         throw new UserRejectedRequestError(error as Error)
       if ((error as ProviderRpcError).code === -32002)
-        throw new ResourceNotFoundRpcError(error as ProviderRpcError)
+        throw new ResourceUnavailableRpcError(error as ProviderRpcError)
       throw error
     }
   }

--- a/packages/connectors/src/metaMask.ts
+++ b/packages/connectors/src/metaMask.ts
@@ -2,7 +2,7 @@ import type { Chain } from '@wagmi/chains'
 import type { Address } from 'abitype'
 import {
   ProviderRpcError,
-  ResourceNotFoundRpcError,
+  ResourceUnavailableRpcError,
   UserRejectedRequestError,
   getAddress,
 } from 'viem'
@@ -119,7 +119,7 @@ export class MetaMaskConnector extends InjectedConnector {
             // Or MetaMask is already open
             if (
               (error as ProviderRpcError).code ===
-              new ResourceNotFoundRpcError(error as ProviderRpcError).code
+              new ResourceUnavailableRpcError(error as ProviderRpcError).code
             )
               throw error
           }
@@ -149,7 +149,7 @@ export class MetaMaskConnector extends InjectedConnector {
       if (this.isUserRejectedRequestError(error))
         throw new UserRejectedRequestError(error as Error)
       if ((error as ProviderRpcError).code === -32002)
-        throw new ResourceNotFoundRpcError(error as ProviderRpcError)
+        throw new ResourceUnavailableRpcError(error as ProviderRpcError)
       throw error
     }
   }


### PR DESCRIPTION
## Description

When I looked at viem's ​​code, when the error code was -32002, I think I should throw ResourceUnavailableRpcError instead of ResourceNotFoundRpcError.

I attach the captured part of my project error console screen and the code of viem as below.

![image](https://github.com/wagmi-dev/references/assets/7166022/ed144812-de0b-431c-bbcb-1b81fe1e146e)
<img width="628" alt="image" src="https://github.com/wagmi-dev/references/assets/7166022/a3b2782c-28c6-4263-9b6c-b10289678a4b">


## Additional Information

- [X] I read the [contributing docs](/wagmi-dev/references/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address:
0x05C844b78d17E3b4be53eEBb72ec5Bcd32f85ad6