### PR TITLE
fix: remove trailing backslash

### DIFF
--- a/packages/chains/src/evmos.ts
+++ b/packages/chains/src/evmos.ts
@@ -14,6 +14,6 @@ export const evmos = {
     public: { http: ['https://eth.bd.evmos.org:8545'] },
   },
   blockExplorers: {
-    default: { name: 'Evmos Block Explorer', url: 'https://escan.live/' },
+    default: { name: 'Evmos Block Explorer', url: 'https://escan.live' },
   },
 } as const satisfies Chain


### PR DESCRIPTION
## Description

Remove the trailing backslash from the Evmos Block Explorer to maintain consistency with every other block explorer.

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/references/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: joeblau.eth
