### PR TITLE
Adds Chainstack to rpcUrls

### DIFF
--- a/packages/chains/src/mainnet.ts
+++ b/packages/chains/src/mainnet.ts
@@ -14,6 +14,10 @@ export const mainnet = {
       http: ['https://mainnet.infura.io/v3'],
       webSocket: ['wss://mainnet.infura.io/ws/v3'],
     },
+    chainstack: {
+      http: ['https://ethereum-mainnet.core.chainstack.com'],
+      webSocket: ['wss://ethereum-mainnet.core.chainstack.com/ws'],
+    },
     default: {
       http: ['https://cloudflare-eth.com'],
     },


### PR DESCRIPTION
## Description

This adds Chainstack alongside Alchemy and Infura, as it now supports standard global endpoints for Ethereum that follow a more predictable domain structure - (chain)-(network).core.chainstack.com in this case. 

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/references/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: tabascoweb3.eth
