### PR TITLE
refactor: switch address type import

### DIFF
--- a/.changeset/cold-bananas-deliver.md
+++ b/.changeset/cold-bananas-deliver.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/connectors": minor
+---
+
+Changed `Address` type import from ABIType to viem.

--- a/packages/connectors/src/base.ts
+++ b/packages/connectors/src/base.ts
@@ -1,6 +1,6 @@
 import type { Chain } from '@wagmi/chains'
-import { Address } from 'abitype'
 import { default as EventEmitter } from 'eventemitter3'
+import type { Address } from 'viem'
 import { goerli, mainnet } from 'viem/chains'
 
 import { Storage, WalletClient } from './types'

--- a/packages/connectors/src/coinbaseWallet.ts
+++ b/packages/connectors/src/coinbaseWallet.ts
@@ -4,8 +4,8 @@ import type {
 } from '@coinbase/wallet-sdk'
 import type { CoinbaseWalletSDKOptions } from '@coinbase/wallet-sdk/dist/CoinbaseWalletSDK'
 import type { Chain } from '@wagmi/chains'
-import type { Address } from 'abitype'
 import {
+  type Address,
   ProviderRpcError,
   SwitchChainError,
   UserRejectedRequestError,

--- a/packages/connectors/src/injected.ts
+++ b/packages/connectors/src/injected.ts
@@ -1,6 +1,6 @@
 import type { Chain } from '@wagmi/chains'
-import type { Address } from 'abitype'
 import {
+  type Address,
   ProviderRpcError,
   ResourceUnavailableRpcError,
   SwitchChainError,

--- a/packages/connectors/src/metaMask.ts
+++ b/packages/connectors/src/metaMask.ts
@@ -1,6 +1,6 @@
 import type { Chain } from '@wagmi/chains'
-import type { Address } from 'abitype'
 import {
+  type Address,
   ProviderRpcError,
   ResourceUnavailableRpcError,
   UserRejectedRequestError,

--- a/packages/connectors/src/mock/connector.test.ts
+++ b/packages/connectors/src/mock/connector.test.ts
@@ -52,7 +52,7 @@ describe('MockConnector', () => {
         "User rejected the request.
 
         Details: Failed to connect.
-        Version: viem@0.3.35"
+        Version: viem@1.0.0"
       `)
     })
   })
@@ -117,8 +117,8 @@ describe('MockConnector', () => {
               "address": "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e",
             },
             "ensUniversalResolver": {
-              "address": "0xE4Acdd618deED4e6d2f03b9bf62dc6118FC9A4da",
-              "blockCreated": 16773775,
+              "address": "0xc0497E381f536Be9ce14B0dD3817cBcAe57d2F62",
+              "blockCreated": 16966585,
             },
             "multicall3": {
               "address": "0xca11bde05977b3631167028862be2a173976ca11",
@@ -219,7 +219,7 @@ describe('MockConnector', () => {
         "User rejected the request.
 
         Details: Failed to switch chain.
-        Version: viem@0.3.35"
+        Version: viem@1.0.0"
       `)
     })
   })

--- a/packages/connectors/src/mock/provider.test.ts
+++ b/packages/connectors/src/mock/provider.test.ts
@@ -41,7 +41,7 @@ describe('MockProvider', () => {
         "User rejected the request.
 
         Details: Failed to connect.
-        Version: viem@0.3.35"
+        Version: viem@1.0.0"
       `)
     })
   })
@@ -102,8 +102,8 @@ describe('MockProvider', () => {
                 "address": "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e",
               },
               "ensUniversalResolver": {
-                "address": "0xE4Acdd618deED4e6d2f03b9bf62dc6118FC9A4da",
-                "blockCreated": 16773775,
+                "address": "0xc0497E381f536Be9ce14B0dD3817cBcAe57d2F62",
+                "blockCreated": 16966585,
               },
               "multicall3": {
                 "address": "0xca11bde05977b3631167028862be2a173976ca11",
@@ -186,7 +186,7 @@ describe('MockProvider', () => {
         "User rejected the request.
 
         Details: Failed to switch chain.
-        Version: viem@0.3.35"
+        Version: viem@1.0.0"
       `)
     })
   })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,8 +118,8 @@ importers:
         specifier: workspace:*
         version: link:../chains
       viem:
-        specifier: 0.3.35
-        version: 0.3.35(typescript@5.0.4)
+        specifier: ^1.0.0
+        version: 1.0.0(typescript@5.0.4)
 
 packages:
 
@@ -1330,10 +1330,10 @@ packages:
       sirv: 2.0.2
     dev: true
 
-  /@wagmi/chains@0.2.16(typescript@5.0.4):
-    resolution: {integrity: sha512-rkWaI2PxCnbD8G07ZZff5QXftnSkYL0h5f4DkHCG3fGYYr/ZDvmCL4bMae7j7A9sAif1csPPBmbCzHp3R5ogCQ==}
+  /@wagmi/chains@1.1.0(typescript@5.0.4):
+    resolution: {integrity: sha512-pWZlxBk0Ql8E7DV8DwqlbBpOyUdaG9UDlQPBxJNALuEK1I0tbQ3AVvSDnlsEIt06UPmPo5o27gzs3hwPQ/A+UA==}
     peerDependencies:
-      typescript: '>=4.9.4'
+      typescript: '>=5.0.4'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -5396,15 +5396,15 @@ packages:
       use-sync-external-store: 1.2.0(react@18.2.0)
     dev: false
 
-  /viem@0.3.35(typescript@5.0.4):
-    resolution: {integrity: sha512-r9GrjAwY5BAehRAMSDJQGpPWGM6sKbAftb3GVny/rLCdjjtK4Zz2B3HOcjOQEM7jo+3LfPWSd85rBkNEpWntiA==}
+  /viem@1.0.0(typescript@5.0.4):
+    resolution: {integrity: sha512-JqdO5TYSuv+/cV9xOmHUKB6qXeyLHtl3gcYYHnfFstfdzivfBttmKtwHiZPdffvcr5DqKsYFT5LLrFnfz5vfLQ==}
     dependencies:
       '@adraffy/ens-normalize': 1.9.0
       '@noble/curves': 1.0.0
       '@noble/hashes': 1.3.0
       '@scure/bip32': 1.3.0
       '@scure/bip39': 1.2.0
-      '@wagmi/chains': 0.2.16(typescript@5.0.4)
+      '@wagmi/chains': 1.1.0(typescript@5.0.4)
       abitype: 0.8.7(typescript@5.0.4)
       isomorphic-ws: 5.0.0(ws@8.12.0)
       ws: 8.12.0(bufferutil@4.0.7)(utf-8-validate@5.0.10)


### PR DESCRIPTION
## Description

Changes `Address` type import from ABIType to viem so it always references the ABIType version coming from viem.

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/references/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: awkweb.eth
