### PR TITLE
add metadata on WalletConnect init

### DIFF
--- a/.changeset/cyan-cougars-shout.md
+++ b/.changeset/cyan-cougars-shout.md
@@ -2,4 +2,4 @@
 "@wagmi/connectors": patch
 ---
 
-Add metadata property to WalletConnect init function
+Added metadata property to WalletConnect init function

--- a/.changeset/cyan-cougars-shout.md
+++ b/.changeset/cyan-cougars-shout.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/connectors": patch
+---
+
+Add metadata property to WalletConnect init function

--- a/.changeset/cyan-cougars-shout.md
+++ b/.changeset/cyan-cougars-shout.md
@@ -1,5 +1,5 @@
 ---
-"@wagmi/connectors": patch
+"@wagmi/connectors": minor
 ---
 
 Added metadata property to WalletConnect init function

--- a/packages/connectors/src/walletConnect.ts
+++ b/packages/connectors/src/walletConnect.ts
@@ -284,7 +284,12 @@ export class WalletConnectConnector extends Connector<
     } = await import('@walletconnect/ethereum-provider')
     const [defaultChain, ...optionalChains] = this.chains.map(({ id }) => id)
     if (defaultChain) {
-      const { projectId, showQrModal = true, qrModalOptions } = this.options
+      const {
+        projectId,
+        showQrModal = true,
+        qrModalOptions,
+        metadata,
+      } = this.options
       this.#provider = await EthereumProvider.init({
         showQrModal,
         qrModalOptions,
@@ -299,6 +304,7 @@ export class WalletConnectConnector extends Connector<
             chain.rpcUrls.default.http[0]!,
           ]),
         ),
+        metadata,
       })
     }
   }


### PR DESCRIPTION
## Description
 
Targeting https://github.com/wagmi-dev/references/issues/336
Metadata parameter was missing on init function, it was declared in the WalletConnectOptions type though

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/references/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address:
