### PR TITLE
feat: add WalletConnect v2 support to Ledger connector

### DIFF
--- a/.changeset/cuddly-sheep-grab.md
+++ b/.changeset/cuddly-sheep-grab.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/connectors": patch
+---
+
+Added WalletConnect v2 support to Ledger connector.

--- a/packages/connectors/package.json
+++ b/packages/connectors/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@coinbase/wallet-sdk": "^3.6.6",
-    "@ledgerhq/connect-kit-loader": "^1.1.0-beta.2",
+    "@ledgerhq/connect-kit-loader": "^1.1.0",
     "@safe-global/safe-apps-provider": "^0.15.2",
     "@safe-global/safe-apps-sdk": "^7.9.0",
     "@walletconnect/ethereum-provider": "2.8.1",

--- a/packages/connectors/package.json
+++ b/packages/connectors/package.json
@@ -22,12 +22,12 @@
   },
   "dependencies": {
     "@coinbase/wallet-sdk": "^3.6.6",
-    "@ledgerhq/connect-kit-loader": "^1.0.1",
+    "@ledgerhq/connect-kit-loader": "^1.1.0-beta.2",
+    "@safe-global/safe-apps-provider": "^0.15.2",
+    "@safe-global/safe-apps-sdk": "^7.9.0",
     "@walletconnect/ethereum-provider": "2.8.1",
     "@walletconnect/legacy-provider": "^2.0.0",
     "@walletconnect/modal": "^2.4.6",
-    "@safe-global/safe-apps-provider": "^0.15.2",
-    "@safe-global/safe-apps-sdk": "^7.9.0",
     "abitype": "0.8.7",
     "eventemitter3": "^4.0.7"
   },

--- a/packages/connectors/src/ledger.ts
+++ b/packages/connectors/src/ledger.ts
@@ -54,7 +54,8 @@ export class LedgerConnector extends Connector<
   #isV1: boolean
 
   get walletConnectVersion(): 1 | 2 {
-    if (this.options.walletConnectVersion) return this.options.walletConnectVersion
+    if (this.options.walletConnectVersion)
+      return this.options.walletConnectVersion
     else if (this.options.projectId) return 2
     return 1
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,8 +87,8 @@ importers:
         specifier: ^3.6.6
         version: 3.6.6
       '@ledgerhq/connect-kit-loader':
-        specifier: ^1.0.1
-        version: 1.0.1
+        specifier: ^1.1.0-beta.2
+        version: 1.1.0-beta.2
       '@safe-global/safe-apps-provider':
         specifier: ^0.15.2
         version: 0.15.2
@@ -772,8 +772,8 @@ packages:
       '@pedrouid/environment': 1.0.1
     dev: false
 
-  /@ledgerhq/connect-kit-loader@1.0.1:
-    resolution: {integrity: sha512-OAJh9rMaypS1ttrSMwPznXqglJGcP3WPTTgz9YAKfkaMyUtZcHx7hCj4d6f7DdSVZOgWcyEYfZ8M2QrA2gtvgQ==}
+  /@ledgerhq/connect-kit-loader@1.1.0-beta.2:
+    resolution: {integrity: sha512-PTz7+Ge+Q+fmyU62BAuJe036DNE2zCwF+s8Yo8UCxmE9X/dWUHv9nmZrUKXgc6TUx9e4jtTbCr0s8amepJHA8Q==}
     dev: false
 
   /@lit-labs/ssr-dom-shim@1.1.1:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,8 +87,8 @@ importers:
         specifier: ^3.6.6
         version: 3.6.6
       '@ledgerhq/connect-kit-loader':
-        specifier: ^1.1.0-beta.2
-        version: 1.1.0-beta.2
+        specifier: ^1.1.0
+        version: 1.1.0
       '@safe-global/safe-apps-provider':
         specifier: ^0.15.2
         version: 0.15.2
@@ -772,8 +772,8 @@ packages:
       '@pedrouid/environment': 1.0.1
     dev: false
 
-  /@ledgerhq/connect-kit-loader@1.1.0-beta.2:
-    resolution: {integrity: sha512-PTz7+Ge+Q+fmyU62BAuJe036DNE2zCwF+s8Yo8UCxmE9X/dWUHv9nmZrUKXgc6TUx9e4jtTbCr0s8amepJHA8Q==}
+  /@ledgerhq/connect-kit-loader@1.1.0:
+    resolution: {integrity: sha512-HUy12FEczoWY2FPubnsm1uOA8tkVWc0j90i47suThV3C9NL2xx69ZAIEU3Ytzs2bwLek9S1Q2S1VQJvA+3Ygkg==}
     dev: false
 
   /@lit-labs/ssr-dom-shim@1.1.1:


### PR DESCRIPTION
## Description

Adds support for WalletConnect v2 to the Ledger connector.

The Ledger Connect Kit is currently in beta, will update package.json to the final one when released. No changes expected to the connector until the final CK release.

The update enables new options for WalletConnect v2

- walletConnectVersion?: 1 | 2
- projectId?: EthereumProviderOptions['projectId']
- requiredChains?: number[]
- requiredMethods?: string[]
- optionalMethods?: string[]
- requiredEvents?: string[]
- optionalEvents?: string[]

Support for WalletConnect v1 is still kept as it can be used by specifying a custom bridge URL.

To test it

- update the connector instance on the demo with the new options

        walletConnectVersion: 2,
        requiredChains: [1],
        projectId: 'a test id',

- Ledger Extension on Safari
    - Open the example application on Safari iOS or macOS
    - follow instructions to install and enable the extension
    - connect using the Extension
- WalletConnect and Ledger Live
    - Open the example application on Chrome iOS or macOS
    - install Ledger Live if not installed yet using the install link
    - connect with Ledger Live using the QR code or the button

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/references/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)
