### PR TITLE
Add BaseGoerli multicall address

### DIFF
--- a/.changeset/twelve-doors-destroy.md
+++ b/.changeset/twelve-doors-destroy.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/chains": minor
+---
+
+Added multicall3 for Base Goerli

--- a/packages/chains/src/baseGoerli.ts
+++ b/packages/chains/src/baseGoerli.ts
@@ -23,5 +23,11 @@ export const baseGoerli = {
       url: 'https://goerli.basescan.org',
     },
   },
+  contracts: {
+    multicall3: {
+      address: '0xca11bde05977b3631167028862be2a173976ca11',
+      blockCreated: 1376988,
+    },
+  },
   testnet: true,
 } as const satisfies Chain


### PR DESCRIPTION
## Description

Adds multicall contract deployment to base goerli: https://goerli.basescan.org/address/0xca11bde05977b3631167028862be2a173976ca11#code

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/references/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address:
