### PR TITLE
fix: add explicit type annotations for `getWalletClient()` returns

### DIFF
--- a/.changeset/wicked-kiwis-speak.md
+++ b/.changeset/wicked-kiwis-speak.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/connectors": patch
+---
+
+Added explicit type annotations for the `getWalletClient()` method.

--- a/packages/connectors/src/coinbaseWallet.ts
+++ b/packages/connectors/src/coinbaseWallet.ts
@@ -17,6 +17,7 @@ import {
 
 import { Connector } from './base'
 import { ChainNotConfiguredForConnectorError } from './errors'
+import type { WalletClient } from './types'
 import { normalizeChainId } from './utils/normalizeChainId'
 
 type Options = Omit<CoinbaseWalletSDKOptions, 'reloadOnDisconnect'> & {
@@ -164,7 +165,9 @@ export class CoinbaseWalletConnector extends Connector<
     return this.#provider
   }
 
-  async getWalletClient({ chainId }: { chainId?: number } = {}) {
+  async getWalletClient({
+    chainId,
+  }: { chainId?: number } = {}): Promise<WalletClient> {
     const [provider, account] = await Promise.all([
       this.getProvider(),
       this.getAccount(),

--- a/packages/connectors/src/injected.ts
+++ b/packages/connectors/src/injected.ts
@@ -16,7 +16,7 @@ import {
   ChainNotConfiguredForConnectorError,
   ConnectorNotFoundError,
 } from './errors'
-import { WindowProvider } from './types'
+import type { WalletClient, WindowProvider } from './types'
 import { getInjectedName } from './utils/getInjectedName'
 import { normalizeChainId } from './utils/normalizeChainId'
 
@@ -163,7 +163,9 @@ export class InjectedConnector extends Connector<
     return this.#provider
   }
 
-  async getWalletClient({ chainId }: { chainId?: number } = {}) {
+  async getWalletClient({
+    chainId,
+  }: { chainId?: number } = {}): Promise<WalletClient> {
     const [provider, account] = await Promise.all([
       this.getProvider(),
       this.getAccount(),

--- a/packages/connectors/src/ledger.ts
+++ b/packages/connectors/src/ledger.ts
@@ -16,6 +16,7 @@ import {
 } from 'viem'
 
 import { Connector } from './base'
+import type { WalletClient } from './types'
 import { normalizeChainId } from './utils/normalizeChainId'
 
 type LedgerConnectorWcV1Options = {
@@ -157,7 +158,9 @@ export class LedgerConnector extends Connector<
     return this.#provider!
   }
 
-  async getWalletClient({ chainId }: { chainId?: number } = {}) {
+  async getWalletClient({
+    chainId,
+  }: { chainId?: number } = {}): Promise<WalletClient> {
     const [provider, account] = await Promise.all([
       this.getProvider({ chainId }),
       this.getAccount(),

--- a/packages/connectors/src/mock/connector.ts
+++ b/packages/connectors/src/mock/connector.ts
@@ -3,6 +3,7 @@ import { getAddress } from 'viem'
 
 import type { ConnectorData } from '../base'
 import { Connector } from '../base'
+import type { WalletClient } from '../types'
 import { normalizeChainId } from '../utils/normalizeChainId'
 import type { MockProviderOptions } from './provider'
 import { MockProvider } from './provider'
@@ -90,7 +91,7 @@ export class MockConnector extends Connector<
     return this.#provider
   }
 
-  async getWalletClient() {
+  async getWalletClient(): Promise<WalletClient> {
     const provider = await this.getProvider()
     return provider.getWalletClient()
   }

--- a/packages/connectors/src/mock/provider.ts
+++ b/packages/connectors/src/mock/provider.ts
@@ -53,7 +53,7 @@ export class MockProvider {
     return [getAddress(address)]
   }
 
-  getWalletClient() {
+  getWalletClient(): WalletClient {
     const walletClient = this.#walletClient
     if (!walletClient) throw new Error('walletClient not found')
     return walletClient

--- a/packages/connectors/src/safe.ts
+++ b/packages/connectors/src/safe.ts
@@ -5,6 +5,7 @@ import { createWalletClient, custom, getAddress } from 'viem'
 
 import { Connector } from './base'
 import { ConnectorNotFoundError } from './errors'
+import type { WalletClient } from './types'
 import { normalizeChainId } from './utils/normalizeChainId'
 
 export type SafeConnectorProvider = SafeAppProvider
@@ -122,7 +123,9 @@ export class SafeConnector extends Connector<
     return this.#provider
   }
 
-  async getWalletClient({ chainId }: { chainId?: number } = {}) {
+  async getWalletClient({
+    chainId,
+  }: { chainId?: number } = {}): Promise<WalletClient> {
     const provider = await this.getProvider()
     const account = await this.getAccount()
     const chain = this.chains.find((x) => x.id === chainId)

--- a/packages/connectors/src/walletConnect.ts
+++ b/packages/connectors/src/walletConnect.ts
@@ -13,7 +13,7 @@ import {
 } from 'viem'
 
 import { Connector } from './base'
-import { StorageStoreData } from './types'
+import type { StorageStoreData, WalletClient } from './types'
 
 type WalletConnectOptions = {
   /**
@@ -186,7 +186,9 @@ export class WalletConnectConnector extends Connector<
     return this.#provider!
   }
 
-  async getWalletClient({ chainId }: { chainId?: number } = {}) {
+  async getWalletClient({
+    chainId,
+  }: { chainId?: number } = {}): Promise<WalletClient> {
     const [provider, account] = await Promise.all([
       this.getProvider({ chainId }),
       this.getAccount(),

--- a/packages/connectors/src/walletConnectLegacy.ts
+++ b/packages/connectors/src/walletConnectLegacy.ts
@@ -11,7 +11,7 @@ import {
 } from 'viem'
 
 import { Connector } from './base'
-import { StorageStoreData } from './types'
+import type { StorageStoreData, WalletClient } from './types'
 import { normalizeChainId } from './utils/normalizeChainId'
 
 /**
@@ -147,7 +147,9 @@ export class WalletConnectLegacyConnector extends Connector<
     return this.#provider
   }
 
-  async getWalletClient({ chainId }: { chainId?: number } = {}) {
+  async getWalletClient({
+    chainId,
+  }: { chainId?: number } = {}): Promise<WalletClient> {
     const [provider, account] = await Promise.all([
       this.getProvider({ chainId }),
       this.getAccount(),


### PR DESCRIPTION
## Description

Without type inference only, the output of `pnpm build` will look like:
```typescript
declare class MockConnector extends Connector<MockProvider, MockConnectorOptions> {
    // ...
    getWalletClient(): Promise<{
        chain: viem.Chain;
        key: string;
        name: string;
        pollingInterval: number;
        request: viem.EIP1193RequestFn<viem.WalletRpcSchema>;
        transport: viem.TransportConfig<string, viem.EIP1193RequestFn> & Record<string, any>;
        type: string;
        uid: string;
        addChain: (args: viem.AddChainParameters) => Promise<void>;
        deployContract: <TAbi extends readonly unknown[] | viem.Abi, TChainOverride extends viem.Chain | undefined>(args: viem.DeployContractParameters<TAbi, viem.Chain, viem.Account, TChainOverride>) => Promise<`0x${string}`>;
        getAddresses: () => Promise<viem.GetAddressesReturnType>;
        getChainId: () => Promise<number>;
        getPermissions: () => Promise<viem.GetPermissionsReturnType>;
        requestAddresses: () => Promise<viem.RequestAddressesReturnType>;
        requestPermissions: (args: {
            [x: string]: Record<string, any>;
            eth_accounts: Record<string, any>;
        }) => Promise<viem.RequestPermissionsReturnType>;
        sendTransaction: <TChainOverride_1 extends viem.Chain | undefined>(args: viem.SendTransactionParameters<viem.Chain, viem.Account, TChainOverride_1>) => Promise<`0x${string}`>;
        signMessage: (args: viem.SignMessageParameters<viem.Account>) => Promise<`0x${string}`>;
        signTypedData: // ...;
        switchChain: (args: viem.SwitchChainParameters) => Promise<void>;
        watchAsset: (args: viem.WatchAssetParams) => Promise<boolean>;
        writeContract: <TAbi_1 extends readonly unknown[] | viem.Abi, TFunctionName extends string, TChainOverride_2 extends viem.Chain | undefined>(args: viem.WriteContractParameters<TAbi_1, TFunctionName, viem.Chain, viem.Account, TChainOverride_2>) => Promise<`0x${string}`>;
        account: viem.Account;
    }>;
```

This causes (fix https://github.com/wagmi-dev/wagmi/issues/2645):
```
error TS2322: Type 'MockConnector' is not assignable to type 'Connector<any, any>'.
  The types returned by 'getWalletClient(...)' are incompatible between these types.
    Type 'Promise<{ chain: Chain; key: string; name: string; pollingInterval: number; request: EIP1193RequestFn<WalletRpcSchema>; transport: TransportConfig<string, EIP1193RequestFn> & Record<...>; ... 15 more ...; account: Account; }>' is not assignable to type 'Promise<{ account: Account; batch?: { multicall?: boolean | MulticallBatchOptions | undefined; } | undefined; chain: Chain; key: string; name: string; ... 18 more ...; writeContract: <TAbi extends Abi | readonly unknown[], TFunctionName extends string, TChainOverride extends Chain | undefined>(args: WriteContractPar...'.
      Property 'extend' is missing in type '{ chain: Chain; key: string; name: string; pollingInterval: number; request: EIP1193RequestFn<WalletRpcSchema>; transport: TransportConfig<string, EIP1193RequestFn> & Record<...>; ... 15 more ...; account: Account; }' but required in type '{ account: Account; batch?: { multicall?: boolean | MulticallBatchOptions | undefined; } | undefined; chain: Chain; key: string; name: string; pollingInterval: number; ... 17 more ...; writeContract: <TAbi extends Abi | readonly unknown[], TFunctionName extends string, TChainOverride extends Chain | undefined>(args:...'.
```

The output should be:
```

declare class MockConnector extends Connector<MockProvider, MockConnectorOptions> {
    // ...
    getWalletClient(): Promise<WalletClient>;
}
```

This PR might also fix #323 .

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/references/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)
