### PR TITLE
fix: import EthereumProvider instead of default

### DIFF
--- a/.changeset/violet-days-arrive.md
+++ b/.changeset/violet-days-arrive.md
@@ -2,4 +2,4 @@
 "@wagmi/connectors": patch
 ---
 
-Fix EthereumProvider.init is not a function
+Fixed issue importing `EthereumProvider` in Vite environments.

--- a/.changeset/violet-days-arrive.md
+++ b/.changeset/violet-days-arrive.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/connectors": patch
+---
+
+Fix EthereumProvider.init is not a function

--- a/packages/connectors/src/walletConnect.ts
+++ b/packages/connectors/src/walletConnect.ts
@@ -277,11 +277,8 @@ export class WalletConnectConnector extends Connector<
   }
 
   async #initProvider() {
-    const {
-      default: EthereumProvider,
-      OPTIONAL_EVENTS,
-      OPTIONAL_METHODS,
-    } = await import('@walletconnect/ethereum-provider')
+    const { EthereumProvider, OPTIONAL_EVENTS, OPTIONAL_METHODS } =
+      await import('@walletconnect/ethereum-provider')
     const [defaultChain, ...optionalChains] = this.chains.map(({ id }) => id)
     if (defaultChain) {
       const {


### PR DESCRIPTION
## Description

I ran into this `Uncaught (in promise) TypeError: EthereumProvider.init is not a function at WalletConnectConnector.initProvider_fn` error when testing my React components with vitest, and I can saw multiple similar reports:

1. https://github.com/wagmi-dev/references/issues/370
2. https://github.com/wagmi-dev/references/issues/379

The problem I found is how we use dynamic import in ESM like below https://github.com/wagmi-dev/references/blob/eeed52e2d0170324c53c145e54dc089761a414cb/packages/connectors/src/walletConnect.ts#L280-L284

Unfortunately, `init` is missing from `EthereumProvider` in this case.

I've set up a small example here where you can check the `test.cjs` file https://stackblitz.com/edit/stackblitz-starters-4alfhc?file=index.mjs, no bundlers like esbuild or webpack messing around, so it seems it's how the import works, though I haven't yet found the standard to reference.

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/references/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address:
