### PR TITLE
feat: rename optimism chain

### DIFF
--- a/.changeset/tough-icons-rhyme.md
+++ b/.changeset/tough-icons-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/chains": patch
+---
+
+Renamed Optimism chain

--- a/packages/chains/src/optimism.ts
+++ b/packages/chains/src/optimism.ts
@@ -2,7 +2,7 @@ import { Chain } from './types'
 
 export const optimism = {
   id: 10,
-  name: 'Optimism',
+  name: 'OP Mainnet',
   network: 'optimism',
   nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
   rpcUrls: {


### PR DESCRIPTION
## Description

OP Foundation officially renamed the chain to OP Mainnet on the 23rd of June.

https://twitter.com/optimismfnd/status/1672281032962478080


## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/references/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: franm.eth
