### PR TITLE
Fix mantle explorer name

### DIFF
--- a/.changeset/wet-chairs-itch.md
+++ b/.changeset/wet-chairs-itch.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/chains": patch
+---
+
+Removed "Testnet" on mantle mainnet explorer name.

--- a/packages/chains/src/mantle.ts
+++ b/packages/chains/src/mantle.ts
@@ -15,11 +15,11 @@ export const mantle = {
   },
   blockExplorers: {
     etherscan: {
-      name: 'Mantle Testnet Explorer',
+      name: 'Mantle Explorer',
       url: 'https://explorer.mantle.xyz',
     },
     default: {
-      name: 'Mantle Testnet Explorer',
+      name: 'Mantle Explorer',
       url: 'https://explorer.mantle.xyz',
     },
   },


### PR DESCRIPTION
remove "testnet" on mainnet explorer

## Description

_Concise description of proposed changes_

remove "testnet" on mainnet explorer

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/references/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address:
octavioamu.eth