### PR TITLE
Update SKALE Network Chains

### DIFF
--- a/.changeset/spotty-stingrays-count.md
+++ b/.changeset/spotty-stingrays-count.md
@@ -2,4 +2,4 @@
 "@wagmi/chains": patch
 ---
 
-Updated SKALE Network Chains
+Updated SKALE Network Chains with WebSocket RPC URLs and Multicall addresses.

--- a/.changeset/spotty-stingrays-count.md
+++ b/.changeset/spotty-stingrays-count.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/chains": patch
+---
+
+Updated SKALE Network Chains

--- a/packages/chains/src/skale/brawl.ts
+++ b/packages/chains/src/skale/brawl.ts
@@ -16,7 +16,7 @@ export const skaleBlockBrawlers = {
     },
   },
   blockExplorers: {
-    etherscan: {
+    blockscout: {
       name: 'SKALE Explorer',
       url: 'https://frayed-decent-antares.explorer.mainnet.skalenodes.com',
     },

--- a/packages/chains/src/skale/brawl.ts
+++ b/packages/chains/src/skale/brawl.ts
@@ -8,11 +8,11 @@ export const skaleBlockBrawlers = {
   rpcUrls: {
     default: {
       http: ['https://mainnet.skalenodes.com/v1/frayed-decent-antares'],
-      webSocket: ["wss://mainnet.skalenodes.com/v1/ws/frayed-decent-antares"]
+      webSocket: ['wss://mainnet.skalenodes.com/v1/ws/frayed-decent-antares'],
     },
     public: {
       http: ['https://mainnet.skalenodes.com/v1/frayed-decent-antares'],
-      webSocket: ["wss://mainnet.skalenodes.com/v1/ws/frayed-decent-antares"]
+      webSocket: ['wss://mainnet.skalenodes.com/v1/ws/frayed-decent-antares'],
     },
   },
   blockExplorers: {

--- a/packages/chains/src/skale/brawl.ts
+++ b/packages/chains/src/skale/brawl.ts
@@ -8,9 +8,11 @@ export const skaleBlockBrawlers = {
   rpcUrls: {
     default: {
       http: ['https://mainnet.skalenodes.com/v1/frayed-decent-antares'],
+      webSocket: ["wss://mainnet.skalenodes.com/v1/ws/frayed-decent-antares"]
     },
     public: {
       http: ['https://mainnet.skalenodes.com/v1/frayed-decent-antares'],
+      webSocket: ["wss://mainnet.skalenodes.com/v1/ws/frayed-decent-antares"]
     },
   },
   blockExplorers: {

--- a/packages/chains/src/skale/calypso.ts
+++ b/packages/chains/src/skale/calypso.ts
@@ -23,5 +23,10 @@ export const skaleCalypso = {
       url: 'https://honorable-steel-rasalhague.explorer.mainnet.skalenodes.com',
     },
   },
-  contracts: {},
+  contracts: {
+    multicall3: {
+      address: "0xcA11bde05977b3631167028862bE2a173976CA11",
+      blockCreated: 3107626
+    }
+  },
 } as const satisfies Chain

--- a/packages/chains/src/skale/calypso.ts
+++ b/packages/chains/src/skale/calypso.ts
@@ -8,9 +8,11 @@ export const skaleCalypso = {
   rpcUrls: {
     default: {
       http: ['https://mainnet.skalenodes.com/v1/honorable-steel-rasalhague'],
+      webSocket: ["wss://mainnet.skalenodes.com/v1/ws/honorable-steel-rasalhague"]
     },
     public: {
       http: ['https://mainnet.skalenodes.com/v1/honorable-steel-rasalhague'],
+      webSocket: ["wss://mainnet.skalenodes.com/v1/ws/honorable-steel-rasalhague"]
     },
   },
   blockExplorers: {

--- a/packages/chains/src/skale/calypso.ts
+++ b/packages/chains/src/skale/calypso.ts
@@ -16,7 +16,7 @@ export const skaleCalypso = {
     },
   },
   blockExplorers: {
-    etherscan: {
+    blockscout: {
       name: 'SKALE Explorer',
       url: 'https://honorable-steel-rasalhague.explorer.mainnet.skalenodes.com',
     },

--- a/packages/chains/src/skale/calypso.ts
+++ b/packages/chains/src/skale/calypso.ts
@@ -8,11 +8,15 @@ export const skaleCalypso = {
   rpcUrls: {
     default: {
       http: ['https://mainnet.skalenodes.com/v1/honorable-steel-rasalhague'],
-      webSocket: ["wss://mainnet.skalenodes.com/v1/ws/honorable-steel-rasalhague"]
+      webSocket: [
+        'wss://mainnet.skalenodes.com/v1/ws/honorable-steel-rasalhague',
+      ],
     },
     public: {
       http: ['https://mainnet.skalenodes.com/v1/honorable-steel-rasalhague'],
-      webSocket: ["wss://mainnet.skalenodes.com/v1/ws/honorable-steel-rasalhague"]
+      webSocket: [
+        'wss://mainnet.skalenodes.com/v1/ws/honorable-steel-rasalhague',
+      ],
     },
   },
   blockExplorers: {
@@ -27,8 +31,8 @@ export const skaleCalypso = {
   },
   contracts: {
     multicall3: {
-      address: "0xcA11bde05977b3631167028862bE2a173976CA11",
-      blockCreated: 3107626
-    }
+      address: '0xcA11bde05977b3631167028862bE2a173976CA11',
+      blockCreated: 3107626,
+    },
   },
 } as const satisfies Chain

--- a/packages/chains/src/skale/calypsoTestnet.ts
+++ b/packages/chains/src/skale/calypsoTestnet.ts
@@ -7,14 +7,10 @@ export const skaleCalypsoTestnet = {
   nativeCurrency: { name: 'sFUEL', symbol: 'sFUEL', decimals: 18 },
   rpcUrls: {
     default: {
-      http: [
-        'https://staging-v3.skalenodes.com/v1/staging-utter-unripe-menkar',
-      ],
+      http: ['https://staging-v3.skalenodes.com/v1/staging-utter-unripe-menkar'],
     },
     public: {
-      http: [
-        'https://staging-v3.skalenodes.com/v1/staging-utter-unripe-menkar',
-      ],
+      http: ['https://staging-v3.skalenodes.com/v1/staging-utter-unripe-menkar'],
     },
   },
   blockExplorers: {

--- a/packages/chains/src/skale/calypsoTestnet.ts
+++ b/packages/chains/src/skale/calypsoTestnet.ts
@@ -8,9 +8,11 @@ export const skaleCalypsoTestnet = {
   rpcUrls: {
     default: {
       http: ['https://staging-v3.skalenodes.com/v1/staging-utter-unripe-menkar'],
+      webSocket: ["wss://staging-v3.skalenodes.com/v1/ws/staging-utter-unripe-menkar"]
     },
     public: {
       http: ['https://staging-v3.skalenodes.com/v1/staging-utter-unripe-menkar'],
+      webSocket: ["wss://staging-v3.skalenodes.com/v1/ws/staging-utter-unripe-menkar"]
     },
   },
   blockExplorers: {

--- a/packages/chains/src/skale/calypsoTestnet.ts
+++ b/packages/chains/src/skale/calypsoTestnet.ts
@@ -27,6 +27,11 @@ export const skaleCalypsoTestnet = {
       url: 'https://staging-utter-unripe-menkar.explorer.staging-v3.skalenodes.com',
     },
   },
-  contracts: {},
+  contracts: {
+    multicall3: {
+      address: "0xcA11bde05977b3631167028862bE2a173976CA11",
+      blockCreated: 2131424
+    }
+  },
   testnet: true,
 } as const satisfies Chain

--- a/packages/chains/src/skale/calypsoTestnet.ts
+++ b/packages/chains/src/skale/calypsoTestnet.ts
@@ -16,7 +16,7 @@ export const skaleCalypsoTestnet = {
     },
   },
   blockExplorers: {
-    etherscan: {
+    blockscout: {
       name: 'SKALE Explorer',
       url: 'https://staging-utter-unripe-menkar.explorer.staging-v3.skalenodes.com',
     },

--- a/packages/chains/src/skale/calypsoTestnet.ts
+++ b/packages/chains/src/skale/calypsoTestnet.ts
@@ -7,12 +7,20 @@ export const skaleCalypsoTestnet = {
   nativeCurrency: { name: 'sFUEL', symbol: 'sFUEL', decimals: 18 },
   rpcUrls: {
     default: {
-      http: ['https://staging-v3.skalenodes.com/v1/staging-utter-unripe-menkar'],
-      webSocket: ["wss://staging-v3.skalenodes.com/v1/ws/staging-utter-unripe-menkar"]
+      http: [
+        'https://staging-v3.skalenodes.com/v1/staging-utter-unripe-menkar',
+      ],
+      webSocket: [
+        'wss://staging-v3.skalenodes.com/v1/ws/staging-utter-unripe-menkar',
+      ],
     },
     public: {
-      http: ['https://staging-v3.skalenodes.com/v1/staging-utter-unripe-menkar'],
-      webSocket: ["wss://staging-v3.skalenodes.com/v1/ws/staging-utter-unripe-menkar"]
+      http: [
+        'https://staging-v3.skalenodes.com/v1/staging-utter-unripe-menkar',
+      ],
+      webSocket: [
+        'wss://staging-v3.skalenodes.com/v1/ws/staging-utter-unripe-menkar',
+      ],
     },
   },
   blockExplorers: {
@@ -27,9 +35,9 @@ export const skaleCalypsoTestnet = {
   },
   contracts: {
     multicall3: {
-      address: "0xcA11bde05977b3631167028862bE2a173976CA11",
-      blockCreated: 2131424
-    }
+      address: '0xcA11bde05977b3631167028862bE2a173976CA11',
+      blockCreated: 2131424,
+    },
   },
   testnet: true,
 } as const satisfies Chain

--- a/packages/chains/src/skale/chaosTestnet.ts
+++ b/packages/chains/src/skale/chaosTestnet.ts
@@ -7,12 +7,20 @@ export const skaleChaosTestnet = {
   nativeCurrency: { name: 'sFUEL', symbol: 'sFUEL', decimals: 18 },
   rpcUrls: {
     default: {
-      http: ['https://staging-v3.skalenodes.com/v1/staging-fast-active-bellatrix'],
-      webSocket: ["wss://staging-v3.skalenodes.com/v1/ws/staging-fast-active-bellatrix"]
+      http: [
+        'https://staging-v3.skalenodes.com/v1/staging-fast-active-bellatrix',
+      ],
+      webSocket: [
+        'wss://staging-v3.skalenodes.com/v1/ws/staging-fast-active-bellatrix',
+      ],
     },
     public: {
-      http: ['https://staging-v3.skalenodes.com/v1/staging-fast-active-bellatrix'],
-      webSocket: ["wss://staging-v3.skalenodes.com/v1/ws/staging-fast-active-bellatrix"]
+      http: [
+        'https://staging-v3.skalenodes.com/v1/staging-fast-active-bellatrix',
+      ],
+      webSocket: [
+        'wss://staging-v3.skalenodes.com/v1/ws/staging-fast-active-bellatrix',
+      ],
     },
   },
   blockExplorers: {
@@ -27,9 +35,9 @@ export const skaleChaosTestnet = {
   },
   contracts: {
     multicall3: {
-      address: "0xcA11bde05977b3631167028862bE2a173976CA11",
-      blockCreated: 1192202
-    }
+      address: '0xcA11bde05977b3631167028862bE2a173976CA11',
+      blockCreated: 1192202,
+    },
   },
   testnet: true,
 } as const satisfies Chain

--- a/packages/chains/src/skale/chaosTestnet.ts
+++ b/packages/chains/src/skale/chaosTestnet.ts
@@ -27,6 +27,11 @@ export const skaleChaosTestnet = {
       url: 'https://staging-fast-active-bellatrix.explorer.staging-v3.skalenodes.com',
     },
   },
-  contracts: {},
+  contracts: {
+    multicall3: {
+      address: "0xcA11bde05977b3631167028862bE2a173976CA11",
+      blockCreated: 1192202
+    }
+  },
   testnet: true,
 } as const satisfies Chain

--- a/packages/chains/src/skale/chaosTestnet.ts
+++ b/packages/chains/src/skale/chaosTestnet.ts
@@ -16,7 +16,7 @@ export const skaleChaosTestnet = {
     },
   },
   blockExplorers: {
-    etherscan: {
+    blockscout: {
       name: 'SKALE Explorer',
       url: 'https://staging-fast-active-bellatrix.explorer.staging-v3.skalenodes.com',
     },

--- a/packages/chains/src/skale/chaosTestnet.ts
+++ b/packages/chains/src/skale/chaosTestnet.ts
@@ -7,14 +7,12 @@ export const skaleChaosTestnet = {
   nativeCurrency: { name: 'sFUEL', symbol: 'sFUEL', decimals: 18 },
   rpcUrls: {
     default: {
-      http: [
-        'https://staging-v3.skalenodes.com/v1/staging-fast-active-bellatrix',
-      ],
+      http: ['https://staging-v3.skalenodes.com/v1/staging-fast-active-bellatrix'],
+      webSocket: ["wss://staging-v3.skalenodes.com/v1/ws/staging-fast-active-bellatrix"]
     },
     public: {
-      http: [
-        'https://staging-v3.skalenodes.com/v1/staging-fast-active-bellatrix',
-      ],
+      http: ['https://staging-v3.skalenodes.com/v1/staging-fast-active-bellatrix'],
+      webSocket: ["wss://staging-v3.skalenodes.com/v1/ws/staging-fast-active-bellatrix"]
     },
   },
   blockExplorers: {

--- a/packages/chains/src/skale/cryptoBlades.ts
+++ b/packages/chains/src/skale/cryptoBlades.ts
@@ -16,7 +16,7 @@ export const skaleCryptoBlades = {
     },
   },
   blockExplorers: {
-    etherscan: {
+    blockscout: {
       name: 'SKALE Explorer',
       url: 'https://affectionate-immediate-pollux.explorer.mainnet.skalenodes.com',
     },

--- a/packages/chains/src/skale/cryptoBlades.ts
+++ b/packages/chains/src/skale/cryptoBlades.ts
@@ -8,9 +8,11 @@ export const skaleCryptoBlades = {
   rpcUrls: {
     default: {
       http: ['https://mainnet.skalenodes.com/v1/affectionate-immediate-pollux'],
+      webSocket: ["wss://mainnet.skalenodes.com/v1/ws/affectionate-immediate-pollux"]
     },
     public: {
       http: ['https://mainnet.skalenodes.com/v1/affectionate-immediate-pollux'],
+      webSocket: ["wss://mainnet.skalenodes.com/v1/ws/affectionate-immediate-pollux"]
     },
   },
   blockExplorers: {

--- a/packages/chains/src/skale/cryptoBlades.ts
+++ b/packages/chains/src/skale/cryptoBlades.ts
@@ -8,11 +8,15 @@ export const skaleCryptoBlades = {
   rpcUrls: {
     default: {
       http: ['https://mainnet.skalenodes.com/v1/affectionate-immediate-pollux'],
-      webSocket: ["wss://mainnet.skalenodes.com/v1/ws/affectionate-immediate-pollux"]
+      webSocket: [
+        'wss://mainnet.skalenodes.com/v1/ws/affectionate-immediate-pollux',
+      ],
     },
     public: {
       http: ['https://mainnet.skalenodes.com/v1/affectionate-immediate-pollux'],
-      webSocket: ["wss://mainnet.skalenodes.com/v1/ws/affectionate-immediate-pollux"]
+      webSocket: [
+        'wss://mainnet.skalenodes.com/v1/ws/affectionate-immediate-pollux',
+      ],
     },
   },
   blockExplorers: {

--- a/packages/chains/src/skale/cryptoColosseum.ts
+++ b/packages/chains/src/skale/cryptoColosseum.ts
@@ -8,11 +8,11 @@ export const skaleCryptoColosseum = {
   rpcUrls: {
     default: {
       http: ['https://mainnet.skalenodes.com/v1/haunting-devoted-deneb'],
-      webSocket: ["wss://mainnet.skalenodes.com/v1/ws/haunting-devoted-deneb"]
+      webSocket: ['wss://mainnet.skalenodes.com/v1/ws/haunting-devoted-deneb'],
     },
     public: {
       http: ['https://mainnet.skalenodes.com/v1/haunting-devoted-deneb'],
-      webSocket: ["wss://mainnet.skalenodes.com/v1/ws/haunting-devoted-deneb"]
+      webSocket: ['wss://mainnet.skalenodes.com/v1/ws/haunting-devoted-deneb'],
     },
   },
   blockExplorers: {

--- a/packages/chains/src/skale/cryptoColosseum.ts
+++ b/packages/chains/src/skale/cryptoColosseum.ts
@@ -8,9 +8,11 @@ export const skaleCryptoColosseum = {
   rpcUrls: {
     default: {
       http: ['https://mainnet.skalenodes.com/v1/haunting-devoted-deneb'],
+      webSocket: ["wss://mainnet.skalenodes.com/v1/ws/haunting-devoted-deneb"]
     },
     public: {
       http: ['https://mainnet.skalenodes.com/v1/haunting-devoted-deneb'],
+      webSocket: ["wss://mainnet.skalenodes.com/v1/ws/haunting-devoted-deneb"]
     },
   },
   blockExplorers: {

--- a/packages/chains/src/skale/cryptoColosseum.ts
+++ b/packages/chains/src/skale/cryptoColosseum.ts
@@ -16,7 +16,7 @@ export const skaleCryptoColosseum = {
     },
   },
   blockExplorers: {
-    etherscan: {
+    blockscout: {
       name: 'SKALE Explorer',
       url: 'https://haunting-devoted-deneb.explorer.mainnet.skalenodes.com',
     },

--- a/packages/chains/src/skale/europa.ts
+++ b/packages/chains/src/skale/europa.ts
@@ -16,7 +16,7 @@ export const skaleEuropa = {
     },
   },
   blockExplorers: {
-    etherscan: {
+    blockscout: {
       name: 'SKALE Explorer',
       url: 'https://elated-tan-skat.explorer.mainnet.skalenodes.com',
     },

--- a/packages/chains/src/skale/europa.ts
+++ b/packages/chains/src/skale/europa.ts
@@ -8,9 +8,11 @@ export const skaleEuropa = {
   rpcUrls: {
     default: {
       http: ['https://mainnet.skalenodes.com/v1/elated-tan-skat'],
+      webSocket: ["wss://mainnet.skalenodes.com/v1/ws/elated-tan-skat"]
     },
     public: {
       http: ['https://mainnet.skalenodes.com/v1/elated-tan-skat'],
+      webSocket: ["wss://mainnet.skalenodes.com/v1/ws/elated-tan-skat"]
     },
   },
   blockExplorers: {

--- a/packages/chains/src/skale/europa.ts
+++ b/packages/chains/src/skale/europa.ts
@@ -8,11 +8,11 @@ export const skaleEuropa = {
   rpcUrls: {
     default: {
       http: ['https://mainnet.skalenodes.com/v1/elated-tan-skat'],
-      webSocket: ["wss://mainnet.skalenodes.com/v1/ws/elated-tan-skat"]
+      webSocket: ['wss://mainnet.skalenodes.com/v1/ws/elated-tan-skat'],
     },
     public: {
       http: ['https://mainnet.skalenodes.com/v1/elated-tan-skat'],
-      webSocket: ["wss://mainnet.skalenodes.com/v1/ws/elated-tan-skat"]
+      webSocket: ['wss://mainnet.skalenodes.com/v1/ws/elated-tan-skat'],
     },
   },
   blockExplorers: {
@@ -27,8 +27,8 @@ export const skaleEuropa = {
   },
   contracts: {
     multicall3: {
-      address: "0xcA11bde05977b3631167028862bE2a173976CA11",
-      blockCreated: 3113495
-    }
-  }
+      address: '0xcA11bde05977b3631167028862bE2a173976CA11',
+      blockCreated: 3113495,
+    },
+  },
 } as const satisfies Chain

--- a/packages/chains/src/skale/europa.ts
+++ b/packages/chains/src/skale/europa.ts
@@ -23,5 +23,10 @@ export const skaleEuropa = {
       url: 'https://elated-tan-skat.explorer.mainnet.skalenodes.com',
     },
   },
-  contracts: {},
+  contracts: {
+    multicall3: {
+      address: "0xcA11bde05977b3631167028862bE2a173976CA11",
+      blockCreated: 3113495
+    }
+  }
 } as const satisfies Chain

--- a/packages/chains/src/skale/europaTestnet.ts
+++ b/packages/chains/src/skale/europaTestnet.ts
@@ -23,6 +23,11 @@ export const skaleEuropaTestnet = {
       url: 'https://staging-legal-crazy-castor.explorer.staging-v3.skalenodes.com',
     },
   },
-  contracts: {},
+  contracts: {
+    multicall3: {
+      address: "0xcA11bde05977b3631167028862bE2a173976CA11",
+      blockCreated: 2071911
+    }
+  },
   testnet: true,
 } as const satisfies Chain

--- a/packages/chains/src/skale/europaTestnet.ts
+++ b/packages/chains/src/skale/europaTestnet.ts
@@ -8,9 +8,11 @@ export const skaleEuropaTestnet = {
   rpcUrls: {
     default: {
       http: ['https://staging-v3.skalenodes.com/v1/staging-legal-crazy-castor'],
+      webSocket: ["wss://staging-v3.skalenodes.com/v1/ws/staging-legal-crazy-castor"]
     },
     public: {
       http: ['https://staging-v3.skalenodes.com/v1/staging-legal-crazy-castor'],
+      webSocket: ["wss://staging-v3.skalenodes.com/v1/ws/staging-legal-crazy-castor"]
     },
   },
   blockExplorers: {

--- a/packages/chains/src/skale/europaTestnet.ts
+++ b/packages/chains/src/skale/europaTestnet.ts
@@ -16,7 +16,7 @@ export const skaleEuropaTestnet = {
     },
   },
   blockExplorers: {
-    etherscan: {
+    blockscout: {
       name: 'SKALE Explorer',
       url: 'https://staging-legal-crazy-castor.explorer.staging-v3.skalenodes.com',
     },

--- a/packages/chains/src/skale/europaTestnet.ts
+++ b/packages/chains/src/skale/europaTestnet.ts
@@ -8,11 +8,15 @@ export const skaleEuropaTestnet = {
   rpcUrls: {
     default: {
       http: ['https://staging-v3.skalenodes.com/v1/staging-legal-crazy-castor'],
-      webSocket: ["wss://staging-v3.skalenodes.com/v1/ws/staging-legal-crazy-castor"]
+      webSocket: [
+        'wss://staging-v3.skalenodes.com/v1/ws/staging-legal-crazy-castor',
+      ],
     },
     public: {
       http: ['https://staging-v3.skalenodes.com/v1/staging-legal-crazy-castor'],
-      webSocket: ["wss://staging-v3.skalenodes.com/v1/ws/staging-legal-crazy-castor"]
+      webSocket: [
+        'wss://staging-v3.skalenodes.com/v1/ws/staging-legal-crazy-castor',
+      ],
     },
   },
   blockExplorers: {
@@ -27,9 +31,9 @@ export const skaleEuropaTestnet = {
   },
   contracts: {
     multicall3: {
-      address: "0xcA11bde05977b3631167028862bE2a173976CA11",
-      blockCreated: 2071911
-    }
+      address: '0xcA11bde05977b3631167028862bE2a173976CA11',
+      blockCreated: 2071911,
+    },
   },
   testnet: true,
 } as const satisfies Chain

--- a/packages/chains/src/skale/exorde.ts
+++ b/packages/chains/src/skale/exorde.ts
@@ -8,11 +8,11 @@ export const skaleExorde = {
   rpcUrls: {
     default: {
       http: ['https://mainnet.skalenodes.com/v1/light-vast-diphda'],
-      webSocket: ["wss://mainnet.skalenodes.com/v1/ws/light-vast-diphda"]
+      webSocket: ['wss://mainnet.skalenodes.com/v1/ws/light-vast-diphda'],
     },
     public: {
       http: ['https://mainnet.skalenodes.com/v1/light-vast-diphda'],
-      webSocket: ["wss://mainnet.skalenodes.com/v1/ws/light-vast-diphda"]
+      webSocket: ['wss://mainnet.skalenodes.com/v1/ws/light-vast-diphda'],
     },
   },
   blockExplorers: {

--- a/packages/chains/src/skale/exorde.ts
+++ b/packages/chains/src/skale/exorde.ts
@@ -8,9 +8,11 @@ export const skaleExorde = {
   rpcUrls: {
     default: {
       http: ['https://mainnet.skalenodes.com/v1/light-vast-diphda'],
+      webSocket: ["wss://mainnet.skalenodes.com/v1/ws/light-vast-diphda"]
     },
     public: {
       http: ['https://mainnet.skalenodes.com/v1/light-vast-diphda'],
+      webSocket: ["wss://mainnet.skalenodes.com/v1/ws/light-vast-diphda"]
     },
   },
   blockExplorers: {

--- a/packages/chains/src/skale/exorde.ts
+++ b/packages/chains/src/skale/exorde.ts
@@ -16,7 +16,7 @@ export const skaleExorde = {
     },
   },
   blockExplorers: {
-    etherscan: {
+    blockscout: {
       name: 'SKALE Explorer',
       url: 'https://light-vast-diphda.explorer.mainnet.skalenodes.com',
     },

--- a/packages/chains/src/skale/humanProtocol.ts
+++ b/packages/chains/src/skale/humanProtocol.ts
@@ -8,11 +8,11 @@ export const skaleHumanProtocol = {
   rpcUrls: {
     default: {
       http: ['https://mainnet.skalenodes.com/v1/wan-red-ain'],
-      webSocket: ["wss://mainnet.skalenodes.com/v1/ws/wan-red-ain"]
+      webSocket: ['wss://mainnet.skalenodes.com/v1/ws/wan-red-ain'],
     },
     public: {
       http: ['https://mainnet.skalenodes.com/v1/wan-red-ain'],
-      webSocket: ["wss://mainnet.skalenodes.com/v1/ws/wan-red-ain"]
+      webSocket: ['wss://mainnet.skalenodes.com/v1/ws/wan-red-ain'],
     },
   },
   blockExplorers: {

--- a/packages/chains/src/skale/humanProtocol.ts
+++ b/packages/chains/src/skale/humanProtocol.ts
@@ -16,7 +16,7 @@ export const skaleHumanProtocol = {
     },
   },
   blockExplorers: {
-    etherscan: {
+    blockscout: {
       name: 'SKALE Explorer',
       url: 'https://wan-red-ain.explorer.mainnet.skalenodes.com',
     },

--- a/packages/chains/src/skale/humanProtocol.ts
+++ b/packages/chains/src/skale/humanProtocol.ts
@@ -8,9 +8,11 @@ export const skaleHumanProtocol = {
   rpcUrls: {
     default: {
       http: ['https://mainnet.skalenodes.com/v1/wan-red-ain'],
+      webSocket: ["wss://mainnet.skalenodes.com/v1/ws/wan-red-ain"]
     },
     public: {
       http: ['https://mainnet.skalenodes.com/v1/wan-red-ain'],
+      webSocket: ["wss://mainnet.skalenodes.com/v1/ws/wan-red-ain"]
     },
   },
   blockExplorers: {

--- a/packages/chains/src/skale/nebula.ts
+++ b/packages/chains/src/skale/nebula.ts
@@ -23,5 +23,10 @@ export const skaleNebula = {
       url: 'https://green-giddy-denebola.explorer.mainnet.skalenodes.com',
     },
   },
-  contracts: {},
+  contracts: {
+    multicall3: {
+      address: "0xcA11bde05977b3631167028862bE2a173976CA11",
+      blockCreated: 2372986
+    }
+  }
 } as const satisfies Chain

--- a/packages/chains/src/skale/nebula.ts
+++ b/packages/chains/src/skale/nebula.ts
@@ -16,7 +16,7 @@ export const skaleNebula = {
     },
   },
   blockExplorers: {
-    etherscan: {
+    blockscout: {
       name: 'SKALE Explorer',
       url: 'https://green-giddy-denebola.explorer.mainnet.skalenodes.com',
     },

--- a/packages/chains/src/skale/nebula.ts
+++ b/packages/chains/src/skale/nebula.ts
@@ -8,11 +8,11 @@ export const skaleNebula = {
   rpcUrls: {
     default: {
       http: ['https://mainnet.skalenodes.com/v1/green-giddy-denebola'],
-      webSocket: ["wss://mainnet.skalenodes.com/v1/ws/green-giddy-denebola"]
+      webSocket: ['wss://mainnet.skalenodes.com/v1/ws/green-giddy-denebola'],
     },
     public: {
       http: ['https://mainnet.skalenodes.com/v1/green-giddy-denebola'],
-      webSocket: ["wss://mainnet.skalenodes.com/v1/ws/green-giddy-denebola"]
+      webSocket: ['wss://mainnet.skalenodes.com/v1/ws/green-giddy-denebola'],
     },
   },
   blockExplorers: {
@@ -27,8 +27,8 @@ export const skaleNebula = {
   },
   contracts: {
     multicall3: {
-      address: "0xcA11bde05977b3631167028862bE2a173976CA11",
-      blockCreated: 2372986
-    }
-  }
+      address: '0xcA11bde05977b3631167028862bE2a173976CA11',
+      blockCreated: 2372986,
+    },
+  },
 } as const satisfies Chain

--- a/packages/chains/src/skale/nebula.ts
+++ b/packages/chains/src/skale/nebula.ts
@@ -8,9 +8,11 @@ export const skaleNebula = {
   rpcUrls: {
     default: {
       http: ['https://mainnet.skalenodes.com/v1/green-giddy-denebola'],
+      webSocket: ["wss://mainnet.skalenodes.com/v1/ws/green-giddy-denebola"]
     },
     public: {
       http: ['https://mainnet.skalenodes.com/v1/green-giddy-denebola'],
+      webSocket: ["wss://mainnet.skalenodes.com/v1/ws/green-giddy-denebola"]
     },
   },
   blockExplorers: {

--- a/packages/chains/src/skale/nebulaTestnet.ts
+++ b/packages/chains/src/skale/nebulaTestnet.ts
@@ -8,11 +8,15 @@ export const skaleNebulaTestnet = {
   rpcUrls: {
     default: {
       http: ['https://staging-v3.skalenodes.com/v1/staging-faint-slimy-achird'],
-      webSocket: ["wss://staging-v3.skalenodes.com/v1/ws/staging-faint-slimy-achird"]
+      webSocket: [
+        'wss://staging-v3.skalenodes.com/v1/ws/staging-faint-slimy-achird',
+      ],
     },
     public: {
       http: ['https://staging-v3.skalenodes.com/v1/staging-faint-slimy-achird'],
-      webSocket: ["wss://staging-v3.skalenodes.com/v1/ws/staging-faint-slimy-achird"]
+      webSocket: [
+        'wss://staging-v3.skalenodes.com/v1/ws/staging-faint-slimy-achird',
+      ],
     },
   },
   blockExplorers: {
@@ -27,9 +31,9 @@ export const skaleNebulaTestnet = {
   },
   contracts: {
     multicall3: {
-      address: "0xcA11bde05977b3631167028862bE2a173976CA11",
-      blockCreated: 2205882
-    }
+      address: '0xcA11bde05977b3631167028862bE2a173976CA11',
+      blockCreated: 2205882,
+    },
   },
   testnet: true,
 } as const satisfies Chain

--- a/packages/chains/src/skale/nebulaTestnet.ts
+++ b/packages/chains/src/skale/nebulaTestnet.ts
@@ -16,7 +16,7 @@ export const skaleNebulaTestnet = {
     },
   },
   blockExplorers: {
-    etherscan: {
+    blockscout: {
       name: 'SKALE Explorer',
       url: 'https://staging-faint-slimy-achird.explorer.staging-v3.skalenodes.com',
     },

--- a/packages/chains/src/skale/nebulaTestnet.ts
+++ b/packages/chains/src/skale/nebulaTestnet.ts
@@ -23,6 +23,11 @@ export const skaleNebulaTestnet = {
       url: 'https://staging-faint-slimy-achird.explorer.staging-v3.skalenodes.com',
     },
   },
-  contracts: {},
+  contracts: {
+    multicall3: {
+      address: "0xcA11bde05977b3631167028862bE2a173976CA11",
+      blockCreated: 2205882
+    }
+  },
   testnet: true,
 } as const satisfies Chain

--- a/packages/chains/src/skale/nebulaTestnet.ts
+++ b/packages/chains/src/skale/nebulaTestnet.ts
@@ -8,9 +8,11 @@ export const skaleNebulaTestnet = {
   rpcUrls: {
     default: {
       http: ['https://staging-v3.skalenodes.com/v1/staging-faint-slimy-achird'],
+      webSocket: ["wss://staging-v3.skalenodes.com/v1/ws/staging-faint-slimy-achird"]
     },
     public: {
       http: ['https://staging-v3.skalenodes.com/v1/staging-faint-slimy-achird'],
+      webSocket: ["wss://staging-v3.skalenodes.com/v1/ws/staging-faint-slimy-achird"]
     },
   },
   blockExplorers: {

--- a/packages/chains/src/skale/razor.ts
+++ b/packages/chains/src/skale/razor.ts
@@ -16,7 +16,7 @@ export const skaleRazor = {
     },
   },
   blockExplorers: {
-    etherscan: {
+    blockscout: {
       name: 'SKALE Explorer',
       url: 'https://turbulent-unique-scheat.explorer.mainnet.skalenodes.com',
     },

--- a/packages/chains/src/skale/razor.ts
+++ b/packages/chains/src/skale/razor.ts
@@ -8,11 +8,11 @@ export const skaleRazor = {
   rpcUrls: {
     default: {
       http: ['https://mainnet.skalenodes.com/v1/turbulent-unique-scheat'],
-      webSocket: ["wss://mainnet.skalenodes.com/v1/ws/turbulent-unique-scheat"]
+      webSocket: ['wss://mainnet.skalenodes.com/v1/ws/turbulent-unique-scheat'],
     },
     public: {
       http: ['https://mainnet.skalenodes.com/v1/turbulent-unique-scheat'],
-      webSocket: ["wss://mainnet.skalenodes.com/v1/ws/turbulent-unique-scheat"]
+      webSocket: ['wss://mainnet.skalenodes.com/v1/ws/turbulent-unique-scheat'],
     },
   },
   blockExplorers: {

--- a/packages/chains/src/skale/razor.ts
+++ b/packages/chains/src/skale/razor.ts
@@ -8,9 +8,11 @@ export const skaleRazor = {
   rpcUrls: {
     default: {
       http: ['https://mainnet.skalenodes.com/v1/turbulent-unique-scheat'],
+      webSocket: ["wss://mainnet.skalenodes.com/v1/ws/turbulent-unique-scheat"]
     },
     public: {
       http: ['https://mainnet.skalenodes.com/v1/turbulent-unique-scheat'],
+      webSocket: ["wss://mainnet.skalenodes.com/v1/ws/turbulent-unique-scheat"]
     },
   },
   blockExplorers: {

--- a/packages/chains/src/skale/titan.ts
+++ b/packages/chains/src/skale/titan.ts
@@ -8,11 +8,11 @@ export const skaleTitan = {
   rpcUrls: {
     default: {
       http: ['https://mainnet.skalenodes.com/v1/parallel-stormy-spica'],
-      webSocket: ["wss://mainnet.skalenodes.com/v1/ws/parallel-stormy-spica"]
+      webSocket: ['wss://mainnet.skalenodes.com/v1/ws/parallel-stormy-spica'],
     },
     public: {
       http: ['https://mainnet.skalenodes.com/v1/parallel-stormy-spica'],
-      webSocket: ["wss://mainnet.skalenodes.com/v1/ws/parallel-stormy-spica"]
+      webSocket: ['wss://mainnet.skalenodes.com/v1/ws/parallel-stormy-spica'],
     },
   },
   blockExplorers: {
@@ -27,8 +27,8 @@ export const skaleTitan = {
   },
   contracts: {
     multicall3: {
-      address: "0xcA11bde05977b3631167028862bE2a173976CA11",
-      blockCreated: 2076458
-    }
-  }
+      address: '0xcA11bde05977b3631167028862bE2a173976CA11',
+      blockCreated: 2076458,
+    },
+  },
 } as const satisfies Chain

--- a/packages/chains/src/skale/titan.ts
+++ b/packages/chains/src/skale/titan.ts
@@ -23,5 +23,10 @@ export const skaleTitan = {
       url: 'https://parallel-stormy-spica.explorer.mainnet.skalenodes.com',
     },
   },
-  contracts: {},
+  contracts: {
+    multicall3: {
+      address: "0xcA11bde05977b3631167028862bE2a173976CA11",
+      blockCreated: 2076458
+    }
+  }
 } as const satisfies Chain

--- a/packages/chains/src/skale/titan.ts
+++ b/packages/chains/src/skale/titan.ts
@@ -8,9 +8,11 @@ export const skaleTitan = {
   rpcUrls: {
     default: {
       http: ['https://mainnet.skalenodes.com/v1/parallel-stormy-spica'],
+      webSocket: ["wss://mainnet.skalenodes.com/v1/ws/parallel-stormy-spica"]
     },
     public: {
       http: ['https://mainnet.skalenodes.com/v1/parallel-stormy-spica'],
+      webSocket: ["wss://mainnet.skalenodes.com/v1/ws/parallel-stormy-spica"]
     },
   },
   blockExplorers: {

--- a/packages/chains/src/skale/titan.ts
+++ b/packages/chains/src/skale/titan.ts
@@ -16,7 +16,7 @@ export const skaleTitan = {
     },
   },
   blockExplorers: {
-    etherscan: {
+    blockscout: {
       name: 'SKALE Explorer',
       url: 'https://parallel-stormy-spica.explorer.mainnet.skalenodes.com',
     },

--- a/packages/chains/src/skale/titanTestnet.ts
+++ b/packages/chains/src/skale/titanTestnet.ts
@@ -7,14 +7,12 @@ export const skaleTitanTestnet = {
   nativeCurrency: { name: 'sFUEL', symbol: 'sFUEL', decimals: 18 },
   rpcUrls: {
     default: {
-      http: [
-        'https://staging-v3.skalenodes.com/v1/staging-aware-chief-gianfar',
-      ],
+      http: ['https://staging-v3.skalenodes.com/v1/staging-aware-chief-gianfar'],
+      webSocket: ["wss://staging-v3.skalenodes.com/v1/ws/staging-aware-chief-gianfar"]
     },
     public: {
-      http: [
-        'https://staging-v3.skalenodes.com/v1/staging-aware-chief-gianfar',
-      ],
+      http: ['https://staging-v3.skalenodes.com/v1/staging-aware-chief-gianfar'],
+      webSocket: ["wss://staging-v3.skalenodes.com/v1/ws/staging-aware-chief-gianfar"]
     },
   },
   blockExplorers: {

--- a/packages/chains/src/skale/titanTestnet.ts
+++ b/packages/chains/src/skale/titanTestnet.ts
@@ -7,12 +7,20 @@ export const skaleTitanTestnet = {
   nativeCurrency: { name: 'sFUEL', symbol: 'sFUEL', decimals: 18 },
   rpcUrls: {
     default: {
-      http: ['https://staging-v3.skalenodes.com/v1/staging-aware-chief-gianfar'],
-      webSocket: ["wss://staging-v3.skalenodes.com/v1/ws/staging-aware-chief-gianfar"]
+      http: [
+        'https://staging-v3.skalenodes.com/v1/staging-aware-chief-gianfar',
+      ],
+      webSocket: [
+        'wss://staging-v3.skalenodes.com/v1/ws/staging-aware-chief-gianfar',
+      ],
     },
     public: {
-      http: ['https://staging-v3.skalenodes.com/v1/staging-aware-chief-gianfar'],
-      webSocket: ["wss://staging-v3.skalenodes.com/v1/ws/staging-aware-chief-gianfar"]
+      http: [
+        'https://staging-v3.skalenodes.com/v1/staging-aware-chief-gianfar',
+      ],
+      webSocket: [
+        'wss://staging-v3.skalenodes.com/v1/ws/staging-aware-chief-gianfar',
+      ],
     },
   },
   blockExplorers: {
@@ -27,9 +35,9 @@ export const skaleTitanTestnet = {
   },
   contracts: {
     multicall3: {
-      address: "0xcA11bde05977b3631167028862bE2a173976CA11",
-      blockCreated: 2085155
-    }
+      address: '0xcA11bde05977b3631167028862bE2a173976CA11',
+      blockCreated: 2085155,
+    },
   },
   testnet: true,
 } as const satisfies Chain

--- a/packages/chains/src/skale/titanTestnet.ts
+++ b/packages/chains/src/skale/titanTestnet.ts
@@ -27,6 +27,11 @@ export const skaleTitanTestnet = {
       url: 'https://staging-aware-chief-gianfar.explorer.staging-v3.skalenodes.com',
     },
   },
-  contracts: {},
+  contracts: {
+    multicall3: {
+      address: "0xcA11bde05977b3631167028862bE2a173976CA11",
+      blockCreated: 2085155
+    }
+  },
   testnet: true,
 } as const satisfies Chain

--- a/packages/chains/src/skale/titanTestnet.ts
+++ b/packages/chains/src/skale/titanTestnet.ts
@@ -16,7 +16,7 @@ export const skaleTitanTestnet = {
     },
   },
   blockExplorers: {
-    etherscan: {
+    blockscout: {
       name: 'SKALE Explorer',
       url: 'https://staging-aware-chief-gianfar.explorer.staging-v3.skalenodes.com',
     },


### PR DESCRIPTION
## Description

- Add Multicall3 to SKALE Hub Chains
- Add Websocket Endpoints to All Chains
- Fix Key Name in Explorers to be Blockscout not etherscan
- Fixed formatting on two testnet chains to match the rest

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/references/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: 0x10cE59E8CA76A6148ed77B0f7151Ff743eFa6d14
