### PR TITLE
Add Horizen EON testnet (gobi) and mainnet (eon)

### DIFF
--- a/.changeset/light-toes-relate.md
+++ b/.changeset/light-toes-relate.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/chains": patch
+---
+
+Added Horizen EON.

--- a/packages/chains/src/eon.ts
+++ b/packages/chains/src/eon.ts
@@ -1,0 +1,22 @@
+import { Chain } from 'wagmi'
+ 
+export const eon = {
+  id: 7_332,
+  name: 'Horizen EON',
+  network: 'eon',
+  nativeCurrency: {
+    decimals: 18,
+    name: 'ZEN',
+    symbol: 'ZEN',
+  },
+  rpcUrls: {
+    public: { http: ['https://eon-rpc.horizenlabs.io/ethv1'] },
+    default: { http: ['https://eon-rpc.horizenlabs.io/ethv1'] },
+  },
+  blockExplorers: {
+    etherscan: { name: 'EON Explorer', url: 'https://eon-explorer.horizenlabs.io/' },
+    default: { name: 'EON Explorer', url: 'https://eon-explorer.horizenlabs.io/' },
+  },
+  contracts: {
+  },
+} as const satisfies Chain

--- a/packages/chains/src/eon.ts
+++ b/packages/chains/src/eon.ts
@@ -14,8 +14,7 @@ export const eon = {
     default: { http: ['https://eon-rpc.horizenlabs.io/ethv1'] },
   },
   blockExplorers: {
-    etherscan: { name: 'EON Explorer', url: 'https://eon-explorer.horizenlabs.io/' },
-    default: { name: 'EON Explorer', url: 'https://eon-explorer.horizenlabs.io/' },
+    default: { name: 'EON Explorer', url: 'https://eon-explorer.horizenlabs.io' },
   },
   contracts: {
   },

--- a/packages/chains/src/gobi.ts
+++ b/packages/chains/src/gobi.ts
@@ -1,0 +1,23 @@
+import { Chain } from 'wagmi'
+ 
+export const gobi = {
+  id: 1_663,
+  name: 'Horizen Gobi Testnet',
+  network: 'gobi',
+  nativeCurrency: {
+    decimals: 18,
+    name: 'Test ZEN',
+    symbol: 'tZEN',
+  },
+  rpcUrls: {
+    public: { http: ['https://gobi-testnet.horizenlabs.io/ethv1'] },
+    default: { http: ['https://gobi-testnet.horizenlabs.io/ethv1'] },
+  },
+  blockExplorers: {
+    etherscan: { name: 'Gobi Explorer', url: 'https://gobi-explorer.horizen.io/' },
+    default: { name: 'Gobi Explorer', url: 'https://gobi-explorer.horizen.io/' },
+  },
+  contracts: {
+  },
+  testnet: true,
+} as const satisfies Chain

--- a/packages/chains/src/gobi.ts
+++ b/packages/chains/src/gobi.ts
@@ -14,8 +14,7 @@ export const gobi = {
     default: { http: ['https://gobi-testnet.horizenlabs.io/ethv1'] },
   },
   blockExplorers: {
-    etherscan: { name: 'Gobi Explorer', url: 'https://gobi-explorer.horizen.io/' },
-    default: { name: 'Gobi Explorer', url: 'https://gobi-explorer.horizen.io/' },
+    default: { name: 'Gobi Explorer', url: 'https://gobi-explorer.horizen.io' },
   },
   contracts: {
   },


### PR DESCRIPTION
Added Horizen EON testnet (gobi.ts) and mainnet (eon.ts)

## Description

This patch add the testnet and mainnet of Horizen EON to the EVM chains available with magmi.

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/references/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: 0xb056B90572e6d840409210d13b2742a0F6739337
