### PR TITLE
Updated: SYSCOIN chain. Added: Rollux, RolluxTestnet, SyscoinTestnet

### DIFF
--- a/.changeset/selfish-experts-lay.md
+++ b/.changeset/selfish-experts-lay.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/chains": minor
+---
+
+Updated: SYSCOIN chain. Added: Rollux, RolluxTestnet, SyscoinTestnet

--- a/.changeset/selfish-experts-lay.md
+++ b/.changeset/selfish-experts-lay.md
@@ -1,5 +1,6 @@
 ---
-"@wagmi/chains": minor
+"@wagmi/chains": patch
 ---
 
-Updated: SYSCOIN chain. Added: Rollux, RolluxTestnet, SyscoinTestnet
+Updated syscoin.
+Added rollux, rolluxTestnet & syscoinTestnet.

--- a/.changeset/shiny-apes-kneel.md
+++ b/.changeset/shiny-apes-kneel.md
@@ -1,7 +1,0 @@
----
-"@wagmi/chains": patch
----
-
-Updated: SYSCOIN chain. Added: Rollux, RolluxTestnet, SyscoinTestnet
-@develCuy
-Add ANKR, public and WSS for Rollux and Syscoin.

--- a/.changeset/shiny-apes-kneel.md
+++ b/.changeset/shiny-apes-kneel.md
@@ -1,0 +1,7 @@
+---
+"@wagmi/chains": patch
+---
+
+Updated: SYSCOIN chain. Added: Rollux, RolluxTestnet, SyscoinTestnet
+@develCuy
+Add ANKR, public and WSS for Rollux and Syscoin.

--- a/packages/chains/src/rollux.ts
+++ b/packages/chains/src/rollux.ts
@@ -1,0 +1,25 @@
+import { Chain } from './types'
+
+export const rollux = {
+  id: 570,
+  name: 'Rollux Mainnet',
+  network: 'rollux',
+  nativeCurrency: {
+    decimals: 18,
+    name: 'Syscoin',
+    symbol: 'SYS',
+  },
+  rpcUrls: {
+    default: { http: ['https://rpc.rollux.com'] },
+    public: { http: ['https://rpc.rollux.com'] },
+  },
+  blockExplorers: {
+    default: { name: 'RolluxExplorer', url: 'https://explorer.rollux.com/' },
+  },
+  contracts: {
+    multicall3: {
+      address: '0xcA11bde05977b3631167028862bE2a173976CA11',
+      blockCreated: 119222,
+    },
+  },
+} as const satisfies Chain

--- a/packages/chains/src/rollux.ts
+++ b/packages/chains/src/rollux.ts
@@ -10,8 +10,12 @@ export const rollux = {
     symbol: 'SYS',
   },
   rpcUrls: {
-    default: { http: ['https://rpc.rollux.com'] },
-    public: { http: ['https://rpc.rollux.com'] },
+    default: {
+      http: ['https://rpc.rollux.com'],
+      websocket: ['wss://rpc.rollux.com/wss']
+    },
+    public: { http: ['https://rollux.public-rpc.com/'] },
+    ankr: { http: ['https://rpc.ankr.com/rollux/'] },
   },
   blockExplorers: {
     default: { name: 'RolluxExplorer', url: 'https://explorer.rollux.com/' },

--- a/packages/chains/src/rollux.ts
+++ b/packages/chains/src/rollux.ts
@@ -14,11 +14,10 @@ export const rollux = {
       http: ['https://rpc.rollux.com'],
       websocket: ['wss://rpc.rollux.com/wss']
     },
-    public: { http: ['https://rollux.public-rpc.com/'] },
-    ankr: { http: ['https://rpc.ankr.com/rollux/'] },
+    public: { http: ['https://rollux.public-rpc.com'] },
   },
   blockExplorers: {
-    default: { name: 'RolluxExplorer', url: 'https://explorer.rollux.com/' },
+    default: { name: 'RolluxExplorer', url: 'https://explorer.rollux.com' },
   },
   contracts: {
     multicall3: {

--- a/packages/chains/src/rolluxTestnet.ts
+++ b/packages/chains/src/rolluxTestnet.ts
@@ -1,0 +1,25 @@
+import { Chain } from './types'
+
+export const rolluxTestnet = {
+  id: 57000,
+  name: 'Rollux Testnet',
+  network: 'rollux-testnet',
+  nativeCurrency: {
+    decimals: 18,
+    name: 'Syscoin',
+    symbol: 'SYS',
+  },
+  rpcUrls: {
+    default: { http: ['https://rpc-tanenbaum.rollux.com/'] },
+    public: { http: ['https://rpc-tanenbaum.rollux.com/'] },
+  },
+  blockExplorers: {
+    default: { name: 'RolluxTestnetExplorer', url: 'https://rollux.tanenbaum.io' },
+  },
+  contracts: {
+    multicall3: {
+      address: '0xcA11bde05977b3631167028862bE2a173976CA11',
+      blockCreated: 1813675,
+    },
+  },
+} as const satisfies Chain

--- a/packages/chains/src/rolluxTestnet.ts
+++ b/packages/chains/src/rolluxTestnet.ts
@@ -10,7 +10,10 @@ export const rolluxTestnet = {
     symbol: 'SYS',
   },
   rpcUrls: {
-    default: { http: ['https://rpc-tanenbaum.rollux.com/'] },
+    default: {
+      http: ['https://rpc-tanenbaum.rollux.com/'],
+      websocket: ['wss://rpc-tanenbaum.rollux.com/wss']
+    },
     public: { http: ['https://rpc-tanenbaum.rollux.com/'] },
   },
   blockExplorers: {

--- a/packages/chains/src/syscoin.ts
+++ b/packages/chains/src/syscoin.ts
@@ -14,7 +14,10 @@ export const syscoin = {
       http: ['https://rpc.syscoin.org'],
       websocket: ['wss://rpc.syscoin.org/wss']
     },
-    public: { http: ['https://syscoin.public-rpc.com'] },
+    public: {
+      http: ['https://rpc.syscoin.org'],
+      websocket: ['wss://rpc.syscoin.org/wss']
+    },
   },
   blockExplorers: {
     default: { name: 'SyscoinExplorer', url: 'https://explorer.syscoin.org' },

--- a/packages/chains/src/syscoin.ts
+++ b/packages/chains/src/syscoin.ts
@@ -10,8 +10,12 @@ export const syscoin = {
     symbol: 'SYS',
   },
   rpcUrls: {
-    default: { http: ['https://rpc.syscoin.org'] },
-    public: { http: ['https://rpc.syscoin.org'] },
+    default: {
+      http: ['https://rpc.syscoin.org'],
+      websocket: ['wss://rpc.syscoin.org/wss']
+    },
+    public: { http: ['https://syscoin.public-rpc.com/'] },
+    ankr: { http: ['https://rpc.ankr.com/syscoin'] },
   },
   blockExplorers: {
     default: { name: 'SyscoinExplorer', url: 'https://explorer.syscoin.org' },

--- a/packages/chains/src/syscoin.ts
+++ b/packages/chains/src/syscoin.ts
@@ -14,8 +14,7 @@ export const syscoin = {
       http: ['https://rpc.syscoin.org'],
       websocket: ['wss://rpc.syscoin.org/wss']
     },
-    public: { http: ['https://syscoin.public-rpc.com/'] },
-    ankr: { http: ['https://rpc.ankr.com/syscoin'] },
+    public: { http: ['https://syscoin.public-rpc.com'] },
   },
   blockExplorers: {
     default: { name: 'SyscoinExplorer', url: 'https://explorer.syscoin.org' },

--- a/packages/chains/src/syscoin.ts
+++ b/packages/chains/src/syscoin.ts
@@ -5,7 +5,7 @@ export const syscoin = {
   name: 'Syscoin Mainnet',
   network: 'syscoin',
   nativeCurrency: {
-    decimals: 8,
+    decimals: 18,
     name: 'Syscoin',
     symbol: 'SYS',
   },
@@ -18,8 +18,8 @@ export const syscoin = {
   },
   contracts: {
     multicall3: {
-      address: '0x000562033783B1136159E10d976B519C929cdE8e',
-      blockCreated: 80637,
+      address: '0xcA11bde05977b3631167028862bE2a173976CA11',
+      blockCreated: 287139,
     },
   },
 } as const satisfies Chain

--- a/packages/chains/src/syscoinTestnet.ts
+++ b/packages/chains/src/syscoinTestnet.ts
@@ -2,7 +2,7 @@ import { Chain } from './types'
 
 export const syscoinTestnet = {
   id: 5700,
-  name: 'Tanenbaum Testnet',
+  name: 'Syscoin Tanenbaum Testnet',
   network: 'syscoin-testnet',
   nativeCurrency: {
     decimals: 18,
@@ -10,7 +10,10 @@ export const syscoinTestnet = {
     symbol: 'SYS',
   },
   rpcUrls: {
-    default: { http: ['https://rpc.tanenbaum.io'] },
+    default: {
+      http: ['https://rpc.tanenbaum.io'],
+      websocket: ['wss://rpc.tanenbaum.io/wss']
+    },
     public: { http: ['https://rpc.tanenbaum.io'] },
   },
   blockExplorers: {

--- a/packages/chains/src/syscoinTestnet.ts
+++ b/packages/chains/src/syscoinTestnet.ts
@@ -1,0 +1,25 @@
+import { Chain } from './types'
+
+export const syscoinTestnet = {
+  id: 5700,
+  name: 'Tanenbaum Testnet',
+  network: 'syscoin-testnet',
+  nativeCurrency: {
+    decimals: 18,
+    name: 'Syscoin',
+    symbol: 'SYS',
+  },
+  rpcUrls: {
+    default: { http: ['https://rpc.tanenbaum.io'] },
+    public: { http: ['https://rpc.tanenbaum.io'] },
+  },
+  blockExplorers: {
+    default: { name: 'SyscoinTestnetExplorer', url: 'https://tanenbaum.io' },
+  },
+  contracts: {
+    multicall3: {
+      address: '0xcA11bde05977b3631167028862bE2a173976CA11',
+      blockCreated: 271288,
+    },
+  },
+} as const satisfies Chain


### PR DESCRIPTION
## Description

- Changed Syscoin chain native currency decimals to 18.
- Updated multicall addresses to official
- Added Rollux L2
- Added Rollux Testnet L2
- Added Syscoin Tanenbaum Testnet

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/references/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address:
