### PR TITLE
Add PHI Network Smart Chain

### DIFF
--- a/packages/chains/src/phi.ts
+++ b/packages/chains/src/phi.ts
@@ -1,0 +1,40 @@
+import { Chain } from './types'
+
+export const phi = {
+  id: 144,
+  name: 'Phi',
+  network: 'PHI',
+  nativeCurrency: { name: 'PHI', symbol: 'PHI', decimals: 18 },
+  rpcUrls: {
+    alchemy: {
+      http: ['https://connect.phi.network'],
+      webSocket: ['wss://connect.phi.network],
+    },
+    infura: {
+      http: ['https://connect.phi.network'],
+      webSocket: ['wss://connect.phi.network'],
+    },
+    default: {
+      http: ['https://connect.phi.network'],
+    },
+    public: {
+      http: ['https://connect.phi.network'],
+    },
+  },
+  blockExplorers: {
+    etherscan: {
+      name: 'Phiscan',
+      url: 'https://phiscan.com',
+    },
+    default: {
+      name: 'Phiscan',
+      url: 'https://phiscan.com',
+    },
+  },
+  contracts: {
+    multicall3: {
+      address: '0xc2f41B404a6757863AAeF49ff93039421acCd630',
+      blockCreated: 360030,
+    },
+  },
+} as const satisfies Chain

--- a/packages/chains/src/phi.ts
+++ b/packages/chains/src/phi.ts
@@ -2,18 +2,10 @@ import { Chain } from './types'
 
 export const phi = {
   id: 144,
-  name: 'Phi',
+  name: 'PHI Network v2',
   network: 'PHI',
   nativeCurrency: { name: 'PHI', symbol: 'PHI', decimals: 18 },
   rpcUrls: {
-    alchemy: {
-      http: ['https://connect.phi.network'],
-      webSocket: ['wss://connect.phi.network],
-    },
-    infura: {
-      http: ['https://connect.phi.network'],
-      webSocket: ['wss://connect.phi.network'],
-    },
     default: {
       http: ['https://connect.phi.network'],
     },
@@ -30,11 +22,5 @@ export const phi = {
       name: 'Phiscan',
       url: 'https://phiscan.com',
     },
-  },
-  contracts: {
-    multicall3: {
-      address: '0xc2f41B404a6757863AAeF49ff93039421acCd630',
-      blockCreated: 360030,
-    },
-  },
+  }
 } as const satisfies Chain


### PR DESCRIPTION
Add PHI Network Smart Chain To Wagmi

## Description

Add PHI Network Smart Chainn
Chain ID: 144 
block explorer: phiscan.com
rpc url: Connect.phi.network

## Additional Information

PHI Network Is A Decentralized social entertainment economy powered by its own native layer one advanced smart blockchain technology. 

Your ENS/address: phinetwork.eth 
