### PR TITLE
feat : add support for opBNB Testnet chain 🚀

### DIFF
--- a/packages/chains/README.md
+++ b/packages/chains/README.md
@@ -72,6 +72,7 @@ const { chains, provider } = configureChains(
 - `okc`
 - `optimism`
 - `optimismGoerli`
+- `opBNBTestnet`
 - `polygon`
 - `polygonMumbai`
 - `pulsechain`

--- a/packages/chains/src/opBNBTestnet.ts
+++ b/packages/chains/src/opBNBTestnet.ts
@@ -1,0 +1,22 @@
+import { Chain } from './types'
+
+
+export const opBNBTestnet = {
+    id: 5611,
+    name: 'opBNB Testnet',
+    network: 'opBNB Testnet',
+    nativeCurrency: {
+        decimals: 18,
+        name: 'tBNB',
+        symbol: 'tBNB',
+    },
+    rpcUrls: {
+        public: { http: ['https://opbnb-testnet-rpc.bnbchain.org'] },
+        default: { http: ['https://opbnb-testnet-rpc.bnbchain.org'] },
+    },
+    blockExplorers: {
+        etherscan: { name: 'opbnbscan', url: 'https://opbnb-testnet.bscscan.com/' },
+        default: { name: 'opbnbscan', url: 'https://opbnbscan.com/' },
+    },
+    testnet: true,
+} as const satisfies Chain


### PR DESCRIPTION
 feat: add support for opBNB Testnet chain 🚀

## Description

- **Network Name**: opBNB Testnet
- **New RPC URL**: https://opbnb-testnet-rpc.bnbchain.org/
- **ChainID**: 5611
- **Symbol**: tBNB
- **Explorer**: http://opbnbscan.com/

## Additional Information

The opBNB network is the Layer 2 scaling solution for the BNB Smart Chain powered by [bedrock version](https://community.optimism.io/docs/developers/bedrock/) of Optimism OP Stack.

- Note: Regarding the multicall3 contract address, I've created an [Deployment Request](https://github.com/mds1/multicall/issues/137) for its deployment. Once the deployment is complete, I will update the contract address.

Your ENS/address: karangoraniya.eth
