### PR TITLE
feat: add SubWallet wallet

### DIFF
--- a/.changeset/calm-swans-worry.md
+++ b/.changeset/calm-swans-worry.md
@@ -1,0 +1,5 @@
+---
+"@wagmi/connectors": patch
+---
+
+Add SubWallet wallet

--- a/packages/connectors/src/types.ts
+++ b/packages/connectors/src/types.ts
@@ -45,6 +45,7 @@ type InjectedProviderFlags = {
   isRabby?: true
   isRainbow?: true
   isStatus?: true
+  isSubWallet?: true
   isTalisman?: true
   isTally?: true
   isTokenPocket?: true

--- a/packages/connectors/src/utils/getInjectedName.test.ts
+++ b/packages/connectors/src/utils/getInjectedName.test.ts
@@ -57,6 +57,7 @@ describe.each([
   { ethereum: { isRainbow: true }, expected: 'Rainbow' },
   { ethereum: { isStatus: true }, expected: 'Status' },
   { ethereum: { isTalisman: true }, expected: 'Talisman' },
+  { ethereum: { isSubWallet: true }, expected: 'SubWallet' },
   { ethereum: { isTally: true }, expected: 'Taho' },
   {
     ethereum: { isTokenPocket: true, isMetaMask: true },

--- a/packages/connectors/src/utils/getInjectedName.ts
+++ b/packages/connectors/src/utils/getInjectedName.ts
@@ -38,6 +38,7 @@ export function getInjectedName(ethereum?: WindowProvider) {
     if (provider.isRabby) return 'Rabby Wallet'
     if (provider.isRainbow) return 'Rainbow'
     if (provider.isStatus) return 'Status'
+    if (provider.isSubWallet) return 'SubWallet'
     if (provider.isTalisman) return 'Talisman'
     if (provider.isTally) return 'Taho'
     if (provider.isTokenPocket) return 'TokenPocket'


### PR DESCRIPTION
## Description

Adds isSubWallet flag to InjectedProviderFlags for [SubWallet](https://subwallet.app/) browser extension wallet.
Objective is to allow SubWallet to be integrated with RainbowKit, which uses Wagmi InjectedProviderFlags type.

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/references/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address:
