### PR TITLE
feat: add website url field for chains

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -19,6 +19,7 @@ If you wish to contribute to add an additional Chain to `@wagmi/chains`, there a
   - a native currency reference (`nativeCurrency`),
   - a public, credible RPC URL
 - **Nice to haves**
+  - a website (`websiteUrl`)
   - a block explorer (`blockExplorers`)
   - a multicall contract (`contracts.multicall`)
 - **Optional**

--- a/packages/chains/src/arbitrum.ts
+++ b/packages/chains/src/arbitrum.ts
@@ -21,6 +21,7 @@ export const arbitrum = {
       http: ['https://arb1.arbitrum.io/rpc'],
     },
   },
+  websiteUrl: 'https://arbitrum.io/',
   blockExplorers: {
     etherscan: { name: 'Arbiscan', url: 'https://arbiscan.io' },
     default: { name: 'Arbiscan', url: 'https://arbiscan.io' },

--- a/packages/chains/src/arbitrumGoerli.ts
+++ b/packages/chains/src/arbitrumGoerli.ts
@@ -25,6 +25,7 @@ export const arbitrumGoerli = {
       http: ['https://goerli-rollup.arbitrum.io/rpc'],
     },
   },
+  websiteUrl: 'https://arbitrum.io/',
   blockExplorers: {
     etherscan: { name: 'Arbiscan', url: 'https://goerli.arbiscan.io/' },
     default: { name: 'Arbiscan', url: 'https://goerli.arbiscan.io/' },

--- a/packages/chains/src/arbitrumNova.ts
+++ b/packages/chains/src/arbitrumNova.ts
@@ -17,6 +17,7 @@ export const arbitrumNova = {
       http: ['https://nova.arbitrum.io/rpc'],
     },
   },
+  websiteUrl: 'https://arbitrum.io/',
   blockExplorers: {
     etherscan: { name: 'Arbiscan', url: 'https://nova.arbiscan.io' },
     blockScout: {

--- a/packages/chains/src/aurora.ts
+++ b/packages/chains/src/aurora.ts
@@ -14,6 +14,7 @@ export const aurora = {
     default: { http: ['https://mainnet.aurora.dev'] },
     public: { http: ['https://mainnet.aurora.dev'] },
   },
+  websiteUrl: 'https://aurora.dev/',
   blockExplorers: {
     etherscan: { name: 'Aurorascan', url: 'https://aurorascan.dev' },
     default: { name: 'Aurorascan', url: 'https://aurorascan.dev' },

--- a/packages/chains/src/auroraTestnet.ts
+++ b/packages/chains/src/auroraTestnet.ts
@@ -14,6 +14,7 @@ export const auroraTestnet = {
     default: { http: ['https://testnet.aurora.dev'] },
     public: { http: ['https://testnet.aurora.dev'] },
   },
+  websiteUrl: 'https://aurora.dev/',
   blockExplorers: {
     etherscan: { name: 'Aurorascan', url: 'https://testnet.aurorascan.dev' },
     default: { name: 'Aurorascan', url: 'https://testnet.aurorascan.dev' },

--- a/packages/chains/src/avalanche.ts
+++ b/packages/chains/src/avalanche.ts
@@ -13,6 +13,7 @@ export const avalanche = {
     default: { http: ['https://api.avax.network/ext/bc/C/rpc'] },
     public: { http: ['https://api.avax.network/ext/bc/C/rpc'] },
   },
+  websiteUrl: 'https://www.avax.network/',
   blockExplorers: {
     etherscan: { name: 'SnowTrace', url: 'https://snowtrace.io' },
     default: { name: 'SnowTrace', url: 'https://snowtrace.io' },

--- a/packages/chains/src/avalancheFuji.ts
+++ b/packages/chains/src/avalancheFuji.ts
@@ -13,6 +13,7 @@ export const avalancheFuji = {
     default: { http: ['https://api.avax-test.network/ext/bc/C/rpc'] },
     public: { http: ['https://api.avax-test.network/ext/bc/C/rpc'] },
   },
+  websiteUrl: 'https://www.avax.network/',
   blockExplorers: {
     etherscan: { name: 'SnowTrace', url: 'https://testnet.snowtrace.io' },
     default: { name: 'SnowTrace', url: 'https://testnet.snowtrace.io' },

--- a/packages/chains/src/base.ts
+++ b/packages/chains/src/base.ts
@@ -13,6 +13,7 @@ export const base = {
       http: ['https://developer-access-mainnet.base.org'],
     },
   },
+  websiteUrl: 'https://base.org/',
   blockExplorers: {
     blockscout: {
       name: 'Basescout',

--- a/packages/chains/src/baseGoerli.ts
+++ b/packages/chains/src/baseGoerli.ts
@@ -13,6 +13,7 @@ export const baseGoerli = {
       http: ['https://goerli.base.org'],
     },
   },
+  websiteUrl: 'https://base.org/',
   blockExplorers: {
     etherscan: {
       name: 'Basescan',

--- a/packages/chains/src/boba.ts
+++ b/packages/chains/src/boba.ts
@@ -13,6 +13,7 @@ export const boba = {
     default: { http: ['https://mainnet.boba.network'] },
     public: { http: ['https://mainnet.boba.network'] },
   },
+  websiteUrl: 'https://boba.network/',
   blockExplorers: {
     etherscan: { name: 'BOBAScan', url: 'https://bobascan.com' },
     default: { name: 'BOBAScan', url: 'https://bobascan.com' },

--- a/packages/chains/src/bronos.ts
+++ b/packages/chains/src/bronos.ts
@@ -13,6 +13,7 @@ export const bronos = {
     default: { http: ['https://evm.bronos.org'] },
     public: { http: ['https://evm.bronos.org'] },
   },
+  websiteUrl: 'https://bronos.org/',
   blockExplorers: {
     default: { name: 'BronoScan', url: 'https://broscan.bronos.org' },
   },

--- a/packages/chains/src/bronosTestnet.ts
+++ b/packages/chains/src/bronosTestnet.ts
@@ -13,6 +13,7 @@ export const bronosTestnet = {
     default: { http: ['https://evm-testnet.bronos.org'] },
     public: { http: ['https://evm-testnet.bronos.org'] },
   },
+  websiteUrl: 'https://bronos.org/',
   blockExplorers: {
     default: { name: 'BronoScan', url: 'https://tbroscan.bronos.org' },
   },

--- a/packages/chains/src/bsc.ts
+++ b/packages/chains/src/bsc.ts
@@ -13,6 +13,7 @@ export const bsc = {
     default: { http: ['https://rpc.ankr.com/bsc'] },
     public: { http: ['https://rpc.ankr.com/bsc'] },
   },
+  websiteUrl: 'https://www.binance.com/',
   blockExplorers: {
     etherscan: { name: 'BscScan', url: 'https://bscscan.com' },
     default: { name: 'BscScan', url: 'https://bscscan.com' },

--- a/packages/chains/src/bscTestnet.ts
+++ b/packages/chains/src/bscTestnet.ts
@@ -13,6 +13,7 @@ export const bscTestnet = {
     default: { http: ['https://data-seed-prebsc-1-s1.binance.org:8545'] },
     public: { http: ['https://data-seed-prebsc-1-s1.binance.org:8545'] },
   },
+  websiteUrl: 'https://www.binance.com/',
   blockExplorers: {
     etherscan: { name: 'BscScan', url: 'https://testnet.bscscan.com' },
     default: { name: 'BscScan', url: 'https://testnet.bscscan.com' },

--- a/packages/chains/src/bxn.ts
+++ b/packages/chains/src/bxn.ts
@@ -13,6 +13,7 @@ export const bxn = {
       http: ['https://mainnet.blackfort.network/rpc'],
     },
   },
+  websiteUrl: 'https://blackfort.exchange/',
   blockExplorers: {
     default: {
       name: 'Blockscout',

--- a/packages/chains/src/bxnTestnet.ts
+++ b/packages/chains/src/bxnTestnet.ts
@@ -17,6 +17,7 @@ export const bxnTestnet = {
       http: ['https://testnet.blackfort.network/rpc'],
     },
   },
+  websiteUrl: 'https://blackfort.exchange/',
   blockExplorers: {
     default: {
       name: 'Blockscout',

--- a/packages/chains/src/canto.ts
+++ b/packages/chains/src/canto.ts
@@ -13,6 +13,7 @@ export const canto = {
     default: { http: ['https://canto.gravitychain.io'] },
     public: { http: ['https://canto.gravitychain.io'] },
   },
+  websiteUrl: 'https://canto.io/',
   blockExplorers: {
     default: {
       name: 'Tuber.Build (Blockscout)',

--- a/packages/chains/src/celo.ts
+++ b/packages/chains/src/celo.ts
@@ -18,6 +18,7 @@ export const celo = {
       http: ['https://forno.celo.org'],
     },
   },
+  websiteUrl: 'https://celo.org/',
   blockExplorers: {
     default: {
       name: 'Celo Explorer',

--- a/packages/chains/src/celoAlfajores.ts
+++ b/packages/chains/src/celoAlfajores.ts
@@ -20,6 +20,7 @@ export const celoAlfajores = {
       http: ['https://alfajores-forno.celo-testnet.org'],
     },
   },
+  websiteUrl: 'https://celo.org/',
   blockExplorers: {
     default: {
       name: 'Celo Explorer',

--- a/packages/chains/src/celoCannoli.ts
+++ b/packages/chains/src/celoCannoli.ts
@@ -17,6 +17,7 @@ export const celoCannoli = {
       http: ['https://forno.cannoli.celo-testnet.org'],
     },
   },
+  websiteUrl: 'https://celo.org/',
   blockExplorers: {
     default: {
       name: 'Celo Explorer',

--- a/packages/chains/src/cronos.ts
+++ b/packages/chains/src/cronos.ts
@@ -13,6 +13,7 @@ export const cronos = {
     default: { http: ['https://node.croswap.com/rpc'] },
     public: { http: ['https://node.croswap.com/rpc'] },
   },
+  websiteUrl: 'https://cronos.org/',
   blockExplorers: {
     default: { name: 'CronosScan', url: 'https://cronoscan.com' },
   },

--- a/packages/chains/src/cronosTestnet.ts
+++ b/packages/chains/src/cronosTestnet.ts
@@ -13,6 +13,7 @@ export const cronosTestnet = {
     default: { http: ['https://evm-t3.cronos.org'] },
     public: { http: ['https://evm-t3.cronos.org'] },
   },
+  websiteUrl: 'https://cronos.org/',
   blockExplorers: {
     default: {
       name: 'Cronos Explorer',

--- a/packages/chains/src/crossbell.ts
+++ b/packages/chains/src/crossbell.ts
@@ -17,6 +17,7 @@ export const crossbell = {
       http: ['https://rpc.crossbell.io'],
     },
   },
+  websiteUrl: 'https://crossbell.io/',
   blockExplorers: {
     default: { name: 'CrossScan', url: 'https://scan.crossbell.io' },
   },

--- a/packages/chains/src/dfk.ts
+++ b/packages/chains/src/dfk.ts
@@ -17,6 +17,7 @@ export const dfk = {
       http: ['https://subnets.avax.network/defi-kingdoms/dfk-chain/rpc'],
     },
   },
+  websiteUrl: 'https://docs.defikingdoms.com/how-defi-kingdoms-works/defi-kingdoms-blockchain',
   blockExplorers: {
     etherscan: {
       name: 'DFKSubnetScan',

--- a/packages/chains/src/dfk.ts
+++ b/packages/chains/src/dfk.ts
@@ -17,7 +17,8 @@ export const dfk = {
       http: ['https://subnets.avax.network/defi-kingdoms/dfk-chain/rpc'],
     },
   },
-  websiteUrl: 'https://docs.defikingdoms.com/how-defi-kingdoms-works/defi-kingdoms-blockchain',
+  websiteUrl:
+    'https://docs.defikingdoms.com/how-defi-kingdoms-works/defi-kingdoms-blockchain',
   blockExplorers: {
     etherscan: {
       name: 'DFKSubnetScan',

--- a/packages/chains/src/dogechain.ts
+++ b/packages/chains/src/dogechain.ts
@@ -13,6 +13,7 @@ export const dogechain = {
     default: { http: ['https://rpc.dogechain.dog'] },
     public: { http: ['https://rpc.dogechain.dog'] },
   },
+  websiteUrl: 'https://dogechain.dog/',
   blockExplorers: {
     etherscan: {
       name: 'DogeChainExplorer',

--- a/packages/chains/src/edgeware.ts
+++ b/packages/chains/src/edgeware.ts
@@ -13,6 +13,7 @@ export const edgeware = {
     default: { http: ['https://edgeware-evm.jelliedowl.net'] },
     public: { http: ['https://edgeware-evm.jelliedowl.net'] },
   },
+  websiteUrl: 'https://www.edgeware.io/',
   blockExplorers: {
     etherscan: { name: 'Edgscan by Bharathcoorg', url: 'https://edgscan.live' },
     default: { name: 'Edgscan by Bharathcoorg', url: 'https://edgscan.live' },

--- a/packages/chains/src/edgewareTestnet.ts
+++ b/packages/chains/src/edgewareTestnet.ts
@@ -13,6 +13,7 @@ export const edgewareTestnet = {
     default: { http: ['https://beresheet-evm.jelliedowl.net'] },
     public: { http: ['https://beresheet-evm.jelliedowl.net'] },
   },
+  websiteUrl: 'https://www.edgeware.io/',
   blockExplorers: {
     etherscan: {
       name: 'Edgscan by Bharathcoorg',

--- a/packages/chains/src/ekta.ts
+++ b/packages/chains/src/ekta.ts
@@ -13,6 +13,7 @@ export const ekta = {
     public: { http: ['https://main.ekta.io'] },
     default: { http: ['https://main.ekta.io'] },
   },
+  websiteUrl: 'https://www.ekta.io/',
   blockExplorers: {
     default: { name: 'Ektascan', url: 'https://ektascan.io' },
   },

--- a/packages/chains/src/ektaTestnet.ts
+++ b/packages/chains/src/ektaTestnet.ts
@@ -13,6 +13,7 @@ export const ektaTestnet = {
     public: { http: ['https://test.ekta.io:8545'] },
     default: { http: ['https://test.ekta.io:8545'] },
   },
+  websiteUrl: 'https://www.ekta.io/',
   blockExplorers: {
     default: { name: 'Test Ektascan', url: 'https://test.ektascan.io' },
   },

--- a/packages/chains/src/eos.ts
+++ b/packages/chains/src/eos.ts
@@ -13,6 +13,7 @@ export const eos = {
     default: { http: ['https://api.evm.eosnetwork.com'] },
     public: { http: ['https://api.evm.eosnetwork.com'] },
   },
+  websiteUrl: 'https://eos.io/',
   blockExplorers: {
     etherscan: {
       name: 'EOS EVM Explorer',

--- a/packages/chains/src/eosTestnet.ts
+++ b/packages/chains/src/eosTestnet.ts
@@ -13,6 +13,7 @@ export const eosTestnet = {
     default: { http: ['https://api.testnet.evm.eosnetwork.com'] },
     public: { http: ['https://api.testnet.evm.eosnetwork.com'] },
   },
+  websiteUrl: 'https://eos.io/',
   blockExplorers: {
     etherscan: {
       name: 'EOS EVM Testnet Explorer',

--- a/packages/chains/src/evmos.ts
+++ b/packages/chains/src/evmos.ts
@@ -13,6 +13,7 @@ export const evmos = {
     default: { http: ['https://eth.bd.evmos.org:8545'] },
     public: { http: ['https://eth.bd.evmos.org:8545'] },
   },
+  websiteUrl: 'https://evmos.org/',
   blockExplorers: {
     default: { name: 'Evmos Block Explorer', url: 'https://escan.live' },
   },

--- a/packages/chains/src/evmosTestnet.ts
+++ b/packages/chains/src/evmosTestnet.ts
@@ -13,6 +13,7 @@ export const evmosTestnet = {
     default: { http: ['https://eth.bd.evmos.dev:8545'] },
     public: { http: ['https://eth.bd.evmos.dev:8545'] },
   },
+  websiteUrl: 'https://evmos.org/',
   blockExplorers: {
     default: {
       name: 'Evmos Testnet Block Explorer',

--- a/packages/chains/src/fantom.ts
+++ b/packages/chains/src/fantom.ts
@@ -13,6 +13,7 @@ export const fantom = {
     default: { http: ['https://rpc.ankr.com/fantom'] },
     public: { http: ['https://rpc.ankr.com/fantom'] },
   },
+  websiteUrl: 'https://fantom.foundation/',
   blockExplorers: {
     etherscan: { name: 'FTMScan', url: 'https://ftmscan.com' },
     default: { name: 'FTMScan', url: 'https://ftmscan.com' },

--- a/packages/chains/src/fantomTestnet.ts
+++ b/packages/chains/src/fantomTestnet.ts
@@ -13,6 +13,7 @@ export const fantomTestnet = {
     default: { http: ['https://rpc.testnet.fantom.network'] },
     public: { http: ['https://rpc.testnet.fantom.network'] },
   },
+  websiteUrl: 'https://fantom.foundation/',
   blockExplorers: {
     etherscan: { name: 'FTMScan', url: 'https://testnet.ftmscan.com' },
     default: { name: 'FTMScan', url: 'https://testnet.ftmscan.com' },

--- a/packages/chains/src/filecoin.ts
+++ b/packages/chains/src/filecoin.ts
@@ -13,6 +13,7 @@ export const filecoin = {
     default: { http: ['https://api.node.glif.io/rpc/v1'] },
     public: { http: ['https://api.node.glif.io/rpc/v1'] },
   },
+  websiteUrl: 'https://filecoin.io/',
   blockExplorers: {
     default: { name: 'Filfox', url: 'https://filfox.info/en' },
     filscan: { name: 'Filscan', url: 'https://filscan.io' },

--- a/packages/chains/src/filecoinCalibration.ts
+++ b/packages/chains/src/filecoinCalibration.ts
@@ -13,6 +13,7 @@ export const filecoinCalibration: Chain = {
     default: { http: ['https://api.calibration.node.glif.io/rpc/v1'] },
     public: { http: ['https://api.calibration.node.glif.io/rpc/v1'] },
   },
+  websiteUrl: 'https://filecoin.io/',
   blockExplorers: {
     default: { name: 'Filscan', url: 'https://calibration.filscan.io' },
   },

--- a/packages/chains/src/filecoinHyperspace.ts
+++ b/packages/chains/src/filecoinHyperspace.ts
@@ -13,6 +13,7 @@ export const filecoinHyperspace = {
     default: { http: ['https://api.hyperspace.node.glif.io/rpc/v1'] },
     public: { http: ['https://api.hyperspace.node.glif.io/rpc/v1'] },
   },
+  websiteUrl: 'https://filecoin.io/',
   blockExplorers: {
     default: { name: 'Filfox', url: 'https://hyperspace.filfox.info/en' },
     filscan: { name: 'Filscan', url: 'https://hyperspace.filscan.io' },

--- a/packages/chains/src/flare.ts
+++ b/packages/chains/src/flare.ts
@@ -13,6 +13,7 @@ export const flare: Chain = {
     default: { http: ['https://flare-api.flare.network/ext/C/rpc'] },
     public: { http: ['https://flare-api.flare.network/ext/C/rpc'] },
   },
+  websiteUrl: 'https://flare.network/',
   blockExplorers: {
     default: {
       name: 'Flare Explorer',

--- a/packages/chains/src/flareTestnet.ts
+++ b/packages/chains/src/flareTestnet.ts
@@ -13,6 +13,7 @@ export const flareTestnet: Chain = {
     default: { http: ['https://coston2-api.flare.network/ext/C/rpc'] },
     public: { http: ['https://coston2-api.flare.network/ext/C/rpc'] },
   },
+  websiteUrl: 'https://flare.network/',
   blockExplorers: {
     default: {
       name: 'Coston2 Explorer',

--- a/packages/chains/src/foundry.ts
+++ b/packages/chains/src/foundry.ts
@@ -19,4 +19,5 @@ export const foundry = {
       webSocket: ['ws://127.0.0.1:8545'],
     },
   },
+  websiteUrl: 'https://book.getfoundry.sh/',
 } as const satisfies Chain

--- a/packages/chains/src/fuse.ts
+++ b/packages/chains/src/fuse.ts
@@ -9,6 +9,7 @@ export const fuse = {
     default: { http: ['https://rpc.fuse.io'] },
     public: { http: ['https://fuse-mainnet.chainstacklabs.com'] },
   },
+  websiteUrl: 'https://www.fuse.io/',
   blockExplorers: {
     default: { name: 'Fuse Explorer', url: 'https://explorer.fuse.io' },
   },

--- a/packages/chains/src/gnosis.ts
+++ b/packages/chains/src/gnosis.ts
@@ -13,6 +13,7 @@ export const gnosis = {
     default: { http: ['https://rpc.gnosischain.com'] },
     public: { http: ['https://rpc.gnosischain.com'] },
   },
+  websiteUrl: 'https://www.gnosis.io/',
   blockExplorers: {
     etherscan: {
       name: 'Gnosisscan',

--- a/packages/chains/src/gnosisChiado.ts
+++ b/packages/chains/src/gnosisChiado.ts
@@ -13,6 +13,7 @@ export const gnosisChiado = {
     default: { http: ['https://rpc.chiadochain.net'] },
     public: { http: ['https://rpc.chiadochain.net'] },
   },
+  websiteUrl: 'https://www.gnosis.io/',
   blockExplorers: {
     default: {
       name: 'Blockscout',

--- a/packages/chains/src/goerli.ts
+++ b/packages/chains/src/goerli.ts
@@ -21,6 +21,7 @@ export const goerli = {
       http: ['https://rpc.ankr.com/eth_goerli'],
     },
   },
+  websiteUrl: 'https://ethereum.org/',
   blockExplorers: {
     etherscan: {
       name: 'Etherscan',

--- a/packages/chains/src/haqqMainnet.ts
+++ b/packages/chains/src/haqqMainnet.ts
@@ -17,6 +17,7 @@ export const haqqMainnet = {
       http: ['https://rpc.eth.haqq.network'],
     },
   },
+  websiteUrl: 'https://haqq.network/',
   blockExplorers: {
     default: {
       name: 'HAQQ Explorer',

--- a/packages/chains/src/haqqTestedge2.ts
+++ b/packages/chains/src/haqqTestedge2.ts
@@ -17,6 +17,7 @@ export const haqqTestedge2 = {
       http: ['https://rpc.eth.testedge2.haqq.network'],
     },
   },
+  websiteUrl: 'https://haqq.network/',
   blockExplorers: {
     default: {
       name: 'HAQQ Explorer',

--- a/packages/chains/src/hardhat.ts
+++ b/packages/chains/src/hardhat.ts
@@ -13,4 +13,5 @@ export const hardhat = {
     default: { http: ['http://127.0.0.1:8545'] },
     public: { http: ['http://127.0.0.1:8545'] },
   },
+  websiteUrl: 'https://hardhat.org/',
 } as const satisfies Chain

--- a/packages/chains/src/harmonyOne.ts
+++ b/packages/chains/src/harmonyOne.ts
@@ -13,6 +13,7 @@ export const harmonyOne = {
     public: { http: ['https://rpc.ankr.com/harmony'] },
     default: { http: ['https://rpc.ankr.com/harmony'] },
   },
+  websiteUrl: 'https://www.harmony.one/',
   blockExplorers: {
     default: { name: 'Harmony Explorer', url: 'https://explorer.harmony.one' },
   },

--- a/packages/chains/src/iotex.ts
+++ b/packages/chains/src/iotex.ts
@@ -19,6 +19,7 @@ export const iotex = {
       webSocket: ['wss://babel-api.mainnet.iotex.io'],
     },
   },
+  websiteUrl: 'https://iotex.io/',
   blockExplorers: {
     default: { name: 'IoTeXScan', url: 'https://iotexscan.io' },
   },

--- a/packages/chains/src/iotexTestnet.ts
+++ b/packages/chains/src/iotexTestnet.ts
@@ -19,6 +19,7 @@ export const iotexTestnet = {
       webSocket: ['wss://babel-api.testnet.iotex.io'],
     },
   },
+  websiteUrl: 'https://iotex.io/',
   blockExplorers: {
     default: { name: 'IoTeXScan', url: 'https://testnet.iotexscan.io' },
   },

--- a/packages/chains/src/klaytn.ts
+++ b/packages/chains/src/klaytn.ts
@@ -13,6 +13,7 @@ export const klaytn = {
     default: { http: ['https://cypress.fautor.app/archive'] },
     public: { http: ['https://cypress.fautor.app/archive'] },
   },
+  websiteUrl: 'https://klaytn.foundation/',
   blockExplorers: {
     etherscan: { name: 'KlaytnScope', url: 'https://scope.klaytn.com' },
     default: { name: 'KlaytnScope', url: 'https://scope.klaytn.com' },

--- a/packages/chains/src/linea.ts
+++ b/packages/chains/src/linea.ts
@@ -19,6 +19,7 @@ export const linea = {
       webSocket: ['wss://rpc.linea.build'],
     },
   },
+  websiteUrl: 'https://linea.build/',
   blockExplorers: {
     default: {
       name: 'Etherscan',

--- a/packages/chains/src/lineaTestnet.ts
+++ b/packages/chains/src/lineaTestnet.ts
@@ -19,6 +19,7 @@ export const lineaTestnet = {
       webSocket: ['wss://rpc.goerli.linea.build'],
     },
   },
+  websiteUrl: 'https://linea.build/',
   blockExplorers: {
     default: {
       name: 'Etherscan',

--- a/packages/chains/src/mainnet.ts
+++ b/packages/chains/src/mainnet.ts
@@ -21,6 +21,7 @@ export const mainnet = {
       http: ['https://cloudflare-eth.com'],
     },
   },
+  websiteUrl: 'https://ethereum.org/',
   blockExplorers: {
     etherscan: {
       name: 'Etherscan',

--- a/packages/chains/src/mantle.ts
+++ b/packages/chains/src/mantle.ts
@@ -13,6 +13,7 @@ export const mantle = {
     default: { http: ['https://rpc.mantle.xyz'] },
     public: { http: ['https://rpc.mantle.xyz'] },
   },
+  websiteUrl: 'https://www.mantle.xyz/',
   blockExplorers: {
     etherscan: {
       name: 'Mantle Explorer',

--- a/packages/chains/src/mantleTestnet.ts
+++ b/packages/chains/src/mantleTestnet.ts
@@ -13,6 +13,7 @@ export const mantleTestnet = {
     default: { http: ['https://rpc.testnet.mantle.xyz'] },
     public: { http: ['https://rpc.testnet.mantle.xyz'] },
   },
+  websiteUrl: 'https://www.mantle.xyz/',
   blockExplorers: {
     etherscan: {
       name: 'Mantle Testnet Explorer',

--- a/packages/chains/src/metisGoerli.ts
+++ b/packages/chains/src/metisGoerli.ts
@@ -13,6 +13,7 @@ export const metisGoerli = {
     default: { http: ['https://goerli.gateway.metisdevops.link'] },
     public: { http: ['https://goerli.gateway.metisdevops.link'] },
   },
+  websiteUrl: 'https://www.metis.io/',
   blockExplorers: {
     default: {
       name: 'Metis Goerli Explorer',

--- a/packages/chains/src/mev.ts
+++ b/packages/chains/src/mev.ts
@@ -17,6 +17,7 @@ export const mev = {
       http: ['https://rpc.meversemainnet.io'],
     },
   },
+  websiteUrl: 'https://www.meverse.sg/',
   blockExplorers: {
     default: {
       name: 'Explorer',

--- a/packages/chains/src/mevTestnet.ts
+++ b/packages/chains/src/mevTestnet.ts
@@ -17,6 +17,7 @@ export const mevTestnet = {
       http: ['https://rpc.meversetestnet.io'],
     },
   },
+  websiteUrl: 'https://www.meverse.sg/',
   blockExplorers: {
     default: {
       name: 'Explorer',

--- a/packages/chains/src/moonbaseAlpha.ts
+++ b/packages/chains/src/moonbaseAlpha.ts
@@ -19,6 +19,7 @@ export const moonbaseAlpha = {
       webSocket: ['wss://wss.api.moonbase.moonbeam.network'],
     },
   },
+  websiteUrl: 'https://docs.moonbeam.network/learn/platform/networks/moonbase/',
   blockExplorers: {
     default: {
       name: 'Moonscan',

--- a/packages/chains/src/moonbeam.ts
+++ b/packages/chains/src/moonbeam.ts
@@ -19,6 +19,7 @@ export const moonbeam = {
       webSocket: ['wss://moonbeam.public.blastapi.io'],
     },
   },
+  websiteUrl: 'https://docs.moonbeam.network/learn/platform/networks/moonbase/',
   blockExplorers: {
     default: {
       name: 'Moonscan',

--- a/packages/chains/src/moonriver.ts
+++ b/packages/chains/src/moonriver.ts
@@ -19,6 +19,7 @@ export const moonriver = {
       webSocket: ['wss://moonriver.public.blastapi.io'],
     },
   },
+  websiteUrl: 'https://moonbeam.network/networks/moonriver/',
   blockExplorers: {
     default: {
       name: 'Moonscan',

--- a/packages/chains/src/neonDevnet.ts
+++ b/packages/chains/src/neonDevnet.ts
@@ -13,6 +13,7 @@ export const neonDevnet = {
       http: ['https://devnet.neonevm.org'],
     },
   },
+  websiteUrl: 'https://neonevm.org/',
   blockExplorers: {
     default: {
       name: 'Neonscan',

--- a/packages/chains/src/oasys.ts
+++ b/packages/chains/src/oasys.ts
@@ -13,6 +13,7 @@ export const oasys = {
       http: ['https://rpc.mainnet.oasys.games'],
     },
   },
+  websiteUrl: 'https://www.oasys.games/',
   blockExplorers: {
     default: {
       name: 'OasysScan',

--- a/packages/chains/src/optimism.ts
+++ b/packages/chains/src/optimism.ts
@@ -21,6 +21,7 @@ export const optimism = {
       http: ['https://mainnet.optimism.io'],
     },
   },
+  websiteUrl: 'https://www.optimism.io/',
   blockExplorers: {
     etherscan: {
       name: 'Etherscan',

--- a/packages/chains/src/optimismGoerli.ts
+++ b/packages/chains/src/optimismGoerli.ts
@@ -21,6 +21,7 @@ export const optimismGoerli = {
       http: ['https://goerli.optimism.io'],
     },
   },
+  websiteUrl: 'https://www.optimism.io/',
   blockExplorers: {
     etherscan: {
       name: 'Etherscan',

--- a/packages/chains/src/polygon.ts
+++ b/packages/chains/src/polygon.ts
@@ -21,6 +21,7 @@ export const polygon = {
       http: ['https://polygon-rpc.com'],
     },
   },
+  websiteUrl: 'https://polygon.technology/',
   blockExplorers: {
     etherscan: {
       name: 'PolygonScan',

--- a/packages/chains/src/polygonMumbai.ts
+++ b/packages/chains/src/polygonMumbai.ts
@@ -21,6 +21,7 @@ export const polygonMumbai = {
       http: ['https://matic-mumbai.chainstacklabs.com'],
     },
   },
+  websiteUrl: 'https://polygon.technology/',
   blockExplorers: {
     etherscan: {
       name: 'PolygonScan',

--- a/packages/chains/src/polygonZkEvm.ts
+++ b/packages/chains/src/polygonZkEvm.ts
@@ -13,6 +13,7 @@ export const polygonZkEvm = {
       http: ['https://zkevm-rpc.com'],
     },
   },
+  websiteUrl: 'https://polygon.technology/',
   blockExplorers: {
     default: {
       name: 'PolygonScan',

--- a/packages/chains/src/polygonZkEvmTestnet.ts
+++ b/packages/chains/src/polygonZkEvmTestnet.ts
@@ -13,6 +13,7 @@ export const polygonZkEvmTestnet = {
       http: ['https://rpc.public.zkevm-test.net'],
     },
   },
+  websiteUrl: 'https://polygon.technology/',
   blockExplorers: {
     blockscout: {
       name: 'Blockscout',

--- a/packages/chains/src/pulsechain.ts
+++ b/packages/chains/src/pulsechain.ts
@@ -16,6 +16,7 @@ export const pulsechain = {
       webSocket: ['wss://ws.pulsechain.com'],
     },
   },
+  websiteUrl: 'https://pulsechain.com/',
   blockExplorers: {
     default: {
       name: 'PulseScan',

--- a/packages/chains/src/pulsechainV4.ts
+++ b/packages/chains/src/pulsechainV4.ts
@@ -16,6 +16,7 @@ export const pulsechainV4 = {
       webSocket: ['wss://ws.v4.testnet.pulsechain.com'],
     },
   },
+  websiteUrl: 'https://pulsechain.com/',
   blockExplorers: {
     default: {
       name: 'PulseScan',

--- a/packages/chains/src/scrollTestnet.ts
+++ b/packages/chains/src/scrollTestnet.ts
@@ -15,6 +15,7 @@ export const scrollTestnet = {
       webSocket: ['wss://alpha-rpc.scroll.io/l2/ws'],
     },
   },
+  websiteUrl: 'https://scroll.io/',
   blockExplorers: {
     default: {
       name: 'Blockscout',

--- a/packages/chains/src/sepolia.ts
+++ b/packages/chains/src/sepolia.ts
@@ -21,6 +21,7 @@ export const sepolia = {
       http: ['https://rpc.sepolia.org'],
     },
   },
+  websiteUrl: 'https://ethereum.org/',
   blockExplorers: {
     etherscan: {
       name: 'Etherscan',

--- a/packages/chains/src/shardeumSphinx.ts
+++ b/packages/chains/src/shardeumSphinx.ts
@@ -13,6 +13,7 @@ export const shardeumSphinx = {
       http: ['https://sphinx.shardeum.org'],
     },
   },
+  websiteUrl: 'https://shardeum.org/',
   blockExplorers: {
     default: {
       name: 'Shardeum Explorer',

--- a/packages/chains/src/skale/brawl.ts
+++ b/packages/chains/src/skale/brawl.ts
@@ -15,6 +15,7 @@ export const skaleBlockBrawlers = {
       webSocket: ['wss://mainnet.skalenodes.com/v1/ws/frayed-decent-antares'],
     },
   },
+  websiteUrl: 'https://blockbrawlers.com/',
   blockExplorers: {
     blockscout: {
       name: 'SKALE Explorer',

--- a/packages/chains/src/skale/calypso.ts
+++ b/packages/chains/src/skale/calypso.ts
@@ -19,6 +19,7 @@ export const skaleCalypso = {
       ],
     },
   },
+  websiteUrl: 'https://www.calypsohub.network/',
   blockExplorers: {
     blockscout: {
       name: 'SKALE Explorer',

--- a/packages/chains/src/skale/calypsoTestnet.ts
+++ b/packages/chains/src/skale/calypsoTestnet.ts
@@ -23,6 +23,7 @@ export const skaleCalypsoTestnet = {
       ],
     },
   },
+  websiteUrl: 'https://www.calypsohub.network/',
   blockExplorers: {
     blockscout: {
       name: 'SKALE Explorer',

--- a/packages/chains/src/skale/chaosTestnet.ts
+++ b/packages/chains/src/skale/chaosTestnet.ts
@@ -23,6 +23,7 @@ export const skaleChaosTestnet = {
       ],
     },
   },
+  websiteUrl: 'https://docs.skale.network/develop/hubs/open-testnet',
   blockExplorers: {
     blockscout: {
       name: 'SKALE Explorer',

--- a/packages/chains/src/skale/cryptoBlades.ts
+++ b/packages/chains/src/skale/cryptoBlades.ts
@@ -19,6 +19,7 @@ export const skaleCryptoBlades = {
       ],
     },
   },
+  websiteUrl: 'https://www.cryptoblades.io/',
   blockExplorers: {
     blockscout: {
       name: 'SKALE Explorer',

--- a/packages/chains/src/skale/cryptoColosseum.ts
+++ b/packages/chains/src/skale/cryptoColosseum.ts
@@ -15,6 +15,7 @@ export const skaleCryptoColosseum = {
       webSocket: ['wss://mainnet.skalenodes.com/v1/ws/haunting-devoted-deneb'],
     },
   },
+  websiteUrl: 'https://cryptocolosseum.com/',
   blockExplorers: {
     blockscout: {
       name: 'SKALE Explorer',

--- a/packages/chains/src/skale/exorde.ts
+++ b/packages/chains/src/skale/exorde.ts
@@ -15,6 +15,7 @@ export const skaleExorde = {
       webSocket: ['wss://mainnet.skalenodes.com/v1/ws/light-vast-diphda'],
     },
   },
+  websiteUrl: 'https://exorde.network/',
   blockExplorers: {
     blockscout: {
       name: 'SKALE Explorer',

--- a/packages/chains/src/skale/humanProtocol.ts
+++ b/packages/chains/src/skale/humanProtocol.ts
@@ -15,6 +15,7 @@ export const skaleHumanProtocol = {
       webSocket: ['wss://mainnet.skalenodes.com/v1/ws/wan-red-ain'],
     },
   },
+  websiteUrl: 'https://www.humanprotocol.org/',
   blockExplorers: {
     blockscout: {
       name: 'SKALE Explorer',

--- a/packages/chains/src/skale/nebula.ts
+++ b/packages/chains/src/skale/nebula.ts
@@ -15,6 +15,7 @@ export const skaleNebula = {
       webSocket: ['wss://mainnet.skalenodes.com/v1/ws/green-giddy-denebola'],
     },
   },
+  websiteUrl: 'https://nebulachain.io/',
   blockExplorers: {
     blockscout: {
       name: 'SKALE Explorer',

--- a/packages/chains/src/skale/nebulaTestnet.ts
+++ b/packages/chains/src/skale/nebulaTestnet.ts
@@ -19,6 +19,7 @@ export const skaleNebulaTestnet = {
       ],
     },
   },
+  websiteUrl: 'https://nebulachain.io/',
   blockExplorers: {
     blockscout: {
       name: 'SKALE Explorer',

--- a/packages/chains/src/skale/razor.ts
+++ b/packages/chains/src/skale/razor.ts
@@ -15,6 +15,7 @@ export const skaleRazor = {
       webSocket: ['wss://mainnet.skalenodes.com/v1/ws/turbulent-unique-scheat'],
     },
   },
+  websiteUrl: 'https://razor.network/',
   blockExplorers: {
     blockscout: {
       name: 'SKALE Explorer',

--- a/packages/chains/src/syscoin.ts
+++ b/packages/chains/src/syscoin.ts
@@ -13,6 +13,7 @@ export const syscoin = {
     default: { http: ['https://rpc.syscoin.org'] },
     public: { http: ['https://rpc.syscoin.org'] },
   },
+  websiteUrl: 'https://syscoin.org/',
   blockExplorers: {
     default: { name: 'SyscoinExplorer', url: 'https://explorer.syscoin.org' },
   },

--- a/packages/chains/src/taikoTestnetSepolia.ts
+++ b/packages/chains/src/taikoTestnetSepolia.ts
@@ -13,6 +13,7 @@ export const taikoTestnetSepolia = {
       http: ['https://rpc.test.taiko.xyz'],
     },
   },
+  websiteUrl: 'https://taiko.xyz/',
   blockExplorers: {
     default: {
       name: 'blockscout',

--- a/packages/chains/src/taraxa.ts
+++ b/packages/chains/src/taraxa.ts
@@ -13,6 +13,7 @@ export const taraxa = {
       http: ['https://rpc.mainnet.taraxa.io'],
     },
   },
+  websiteUrl: 'https://www.taraxa.io/',
   blockExplorers: {
     default: {
       name: 'Taraxa Explorer',

--- a/packages/chains/src/taraxaTestnet.ts
+++ b/packages/chains/src/taraxaTestnet.ts
@@ -13,6 +13,7 @@ export const taraxaTestnet = {
       http: ['https://rpc.testnet.taraxa.io'],
     },
   },
+  websiteUrl: 'https://www.taraxa.io/',
   blockExplorers: {
     default: {
       name: 'Taraxa Explorer',

--- a/packages/chains/src/telos.ts
+++ b/packages/chains/src/telos.ts
@@ -13,6 +13,7 @@ export const telos = {
     default: { http: ['https://mainnet.telos.net/evm'] },
     public: { http: ['https://mainnet.telos.net/evm'] },
   },
+  websiteUrl: 'https://www.telos.net/',
   blockExplorers: {
     default: {
       name: 'Teloscan',

--- a/packages/chains/src/telosTestnet.ts
+++ b/packages/chains/src/telosTestnet.ts
@@ -13,6 +13,7 @@ export const telosTestnet = {
     default: { http: ['https://testnet.telos.net/evm'] },
     public: { http: ['https://testnet.telos.net/evm'] },
   },
+  websiteUrl: 'https://www.telos.net/',
   blockExplorers: {
     default: {
       name: 'Teloscan (testnet)',

--- a/packages/chains/src/thunderTestnet.ts
+++ b/packages/chains/src/thunderTestnet.ts
@@ -13,6 +13,7 @@ export const thunderTestnet = {
       http: ['https://rpc-testnet.5ire.network'],
     },
   },
+  websiteUrl: 'https://blog.5ire.org/',
   blockExplorers: {
     default: {
       name: '5ireChain Explorer',

--- a/packages/chains/src/types.ts
+++ b/packages/chains/src/types.ts
@@ -20,6 +20,8 @@ export type Chain = {
     default: RpcUrls
     public: RpcUrls
   }
+  /** Website or blog related to the chain */
+  websiteUrl?: string;
   /** Collection of block explorers */
   blockExplorers?: {
     [key: string]: BlockExplorer

--- a/packages/chains/src/types.ts
+++ b/packages/chains/src/types.ts
@@ -21,7 +21,7 @@ export type Chain = {
     public: RpcUrls
   }
   /** Website or blog related to the chain */
-  websiteUrl?: string;
+  websiteUrl?: string
   /** Collection of block explorers */
   blockExplorers?: {
     [key: string]: BlockExplorer

--- a/packages/chains/src/wanchain.ts
+++ b/packages/chains/src/wanchain.ts
@@ -19,6 +19,7 @@ export const wanchain = {
       ],
     },
   },
+  websiteUrl: 'https://www.wanchain.org/',
   blockExplorers: {
     etherscan: {
       name: 'WanScan',

--- a/packages/chains/src/wanchainTestnet.ts
+++ b/packages/chains/src/wanchainTestnet.ts
@@ -13,6 +13,7 @@ export const wanchainTestnet = {
       http: ['https://gwan-ssl.wandevs.org:46891'],
     },
   },
+  websiteUrl: 'https://www.wanchain.org/',
   blockExplorers: {
     etherscan: {
       name: 'WanScanTest',

--- a/packages/chains/src/xdc.ts
+++ b/packages/chains/src/xdc.ts
@@ -13,6 +13,7 @@ export const xdc = {
     default: { http: ['https://rpc.xinfin.network'] },
     public: { http: ['https://rpc.xinfin.network'] },
   },
+  websiteUrl: 'https://xdc.org/',
   blockExplorers: {
     xinfin: { name: 'XinFin', url: 'https://explorer.xinfin.network' },
     default: { name: 'Blocksscan', url: 'https://xdc.blocksscan.io' },

--- a/packages/chains/src/xdcTestnet.ts
+++ b/packages/chains/src/xdcTestnet.ts
@@ -13,6 +13,7 @@ export const xdcTestnet = {
     default: { http: ['https://erpc.apothem.network'] },
     public: { http: ['https://erpc.apothem.network'] },
   },
+  websiteUrl: 'https://xdc.org/',
   blockExplorers: {
     xinfin: { name: 'XinFin', url: 'https://explorer.apothem.network' },
     default: { name: 'Blocksscan', url: 'https://apothem.blocksscan.io' },

--- a/packages/chains/src/zkSync.ts
+++ b/packages/chains/src/zkSync.ts
@@ -19,6 +19,7 @@ export const zkSync = {
       webSocket: ['wss://mainnet.era.zksync.io/ws'],
     },
   },
+  websiteUrl: 'https://zksync.io/',
   blockExplorers: {
     default: {
       name: 'zkExplorer',

--- a/packages/chains/src/zkSyncTestnet.ts
+++ b/packages/chains/src/zkSyncTestnet.ts
@@ -15,6 +15,7 @@ export const zkSyncTestnet = {
       webSocket: ['wss://testnet.era.zksync.dev/ws'],
     },
   },
+  websiteUrl: 'https://zksync.io/',
   blockExplorers: {
     default: {
       name: 'zkExplorer',

--- a/packages/chains/src/zora.ts
+++ b/packages/chains/src/zora.ts
@@ -19,6 +19,7 @@ export const zora = {
       webSocket: ['wss://rpc.zora.energy'],
     },
   },
+  websiteUrl: 'https://zora.energy/',
   blockExplorers: {
     default: { name: 'Explorer', url: 'https://explorer.zora.energy' },
   },

--- a/packages/chains/src/zoraTestnet.ts
+++ b/packages/chains/src/zoraTestnet.ts
@@ -19,6 +19,7 @@ export const zoraTestnet = {
       webSocket: ['wss://testnet.rpc.zora.energy'],
     },
   },
+  websiteUrl: 'https://zora.energy/',
   blockExplorers: {
     default: { name: 'Explorer', url: 'https://testnet.explorer.zora.energy' },
   },


### PR DESCRIPTION
## Description

Add a new field called `websiteUrl` to the `Chain` type which references a website or a documentation related to the chain. For example, the Ethereum chain would have a reference to https://ethereum.org/.

Related to #462 

Question: I tried to add a changeset by selecting `@wagmi/chains` and pressing enter but didn't suceed...

```sh
$ pnpm changeset
🦋  Which packages would you like to include? · No items were selected
🦋  error You must select at least one package to release
🦋  error (You most likely hit enter instead of space!)
🦋  Which packages would you like to include? … 
◯ changed packages
  ◯ @wagmi/chains
◯ unchanged packages
  ◯ @wagmi/connectors
```

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/references/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: leovct.eth
