### PR TITLE
fix(wallet-connect): allow the first chain id to be optional during connector init

### DIFF
--- a/packages/connectors/src/walletConnect.ts
+++ b/packages/connectors/src/walletConnect.ts
@@ -286,8 +286,8 @@ export class WalletConnectConnector extends Connector<
   async #initProvider() {
     const { EthereumProvider, OPTIONAL_EVENTS, OPTIONAL_METHODS } =
       await import('@walletconnect/ethereum-provider')
-    const [defaultChain, ...optionalChains] = this.chains.map(({ id }) => id)
-    if (defaultChain) {
+    const allChainIds = this.chains.map(({ id }) => id)
+    if (allChainIds.length > 0) {
       const {
         projectId,
         showQrModal = true,
@@ -301,8 +301,8 @@ export class WalletConnectConnector extends Connector<
         projectId,
         optionalMethods: OPTIONAL_METHODS,
         optionalEvents: OPTIONAL_EVENTS,
-        chains: [defaultChain],
-        optionalChains: optionalChains.length ? optionalChains : undefined,
+        chains: allChainIds.length === 1 ? allChainIds : undefined,
+        optionalChains: allChainIds,
         rpcMap: Object.fromEntries(
           this.chains.map((chain) => [
             chain.id,


### PR DESCRIPTION
## Description

Resolves: #469 

## Additional Information

If dapp supports multiple networks, it is not correct to assume that the first one is required. Therefore, I decided to define chains parameter (required networks for connection) only if there is one network. Otherwise it should be undefined in order to accept connections with wallets that support other networks except the first one from the list of supported networks by the dapp.
Thanks in advance!

- [x] I read the [contributing docs](/wagmi-dev/references/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)
