### PR TITLE
feat: add ENS registry and universal resolver for Sepolia

### DIFF
--- a/packages/chains/src/sepolia.ts
+++ b/packages/chains/src/sepolia.ts
@@ -1,46 +1,46 @@
-import { Chain } from "./types";
+import { Chain } from './types'
 
 export const sepolia = {
   id: 11_155_111,
-  network: "sepolia",
-  name: "Sepolia",
-  nativeCurrency: { name: "Sepolia Ether", symbol: "SEP", decimals: 18 },
+  network: 'sepolia',
+  name: 'Sepolia',
+  nativeCurrency: { name: 'Sepolia Ether', symbol: 'SEP', decimals: 18 },
   rpcUrls: {
     alchemy: {
-      http: ["https://eth-sepolia.g.alchemy.com/v2"],
-      webSocket: ["wss://eth-sepolia.g.alchemy.com/v2"],
+      http: ['https://eth-sepolia.g.alchemy.com/v2'],
+      webSocket: ['wss://eth-sepolia.g.alchemy.com/v2'],
     },
     infura: {
-      http: ["https://sepolia.infura.io/v3"],
-      webSocket: ["wss://sepolia.infura.io/ws/v3"],
+      http: ['https://sepolia.infura.io/v3'],
+      webSocket: ['wss://sepolia.infura.io/ws/v3'],
     },
     default: {
-      http: ["https://rpc.sepolia.org"],
+      http: ['https://rpc.sepolia.org'],
     },
     public: {
-      http: ["https://rpc.sepolia.org"],
+      http: ['https://rpc.sepolia.org'],
     },
   },
   blockExplorers: {
     etherscan: {
-      name: "Etherscan",
-      url: "https://sepolia.etherscan.io",
+      name: 'Etherscan',
+      url: 'https://sepolia.etherscan.io',
     },
     default: {
-      name: "Etherscan",
-      url: "https://sepolia.etherscan.io",
+      name: 'Etherscan',
+      url: 'https://sepolia.etherscan.io',
     },
   },
   contracts: {
     multicall3: {
-      address: "0xca11bde05977b3631167028862be2a173976ca11",
+      address: '0xca11bde05977b3631167028862be2a173976ca11',
       blockCreated: 6507670,
     },
-    ensRegistry: { address: "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e" },
+    ensRegistry: { address: '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e' },
     ensUniversalResolver: {
-      address: "0x21B000Fd62a880b2125A61e36a284BB757b76025",
+      address: '0x21B000Fd62a880b2125A61e36a284BB757b76025',
       blockCreated: 3914906,
     },
   },
   testnet: true,
-} as const satisfies Chain;
+} as const satisfies Chain

--- a/packages/chains/src/sepolia.ts
+++ b/packages/chains/src/sepolia.ts
@@ -1,41 +1,46 @@
-import { Chain } from './types'
+import { Chain } from "./types";
 
 export const sepolia = {
   id: 11_155_111,
-  network: 'sepolia',
-  name: 'Sepolia',
-  nativeCurrency: { name: 'Sepolia Ether', symbol: 'SEP', decimals: 18 },
+  network: "sepolia",
+  name: "Sepolia",
+  nativeCurrency: { name: "Sepolia Ether", symbol: "SEP", decimals: 18 },
   rpcUrls: {
     alchemy: {
-      http: ['https://eth-sepolia.g.alchemy.com/v2'],
-      webSocket: ['wss://eth-sepolia.g.alchemy.com/v2'],
+      http: ["https://eth-sepolia.g.alchemy.com/v2"],
+      webSocket: ["wss://eth-sepolia.g.alchemy.com/v2"],
     },
     infura: {
-      http: ['https://sepolia.infura.io/v3'],
-      webSocket: ['wss://sepolia.infura.io/ws/v3'],
+      http: ["https://sepolia.infura.io/v3"],
+      webSocket: ["wss://sepolia.infura.io/ws/v3"],
     },
     default: {
-      http: ['https://rpc.sepolia.org'],
+      http: ["https://rpc.sepolia.org"],
     },
     public: {
-      http: ['https://rpc.sepolia.org'],
+      http: ["https://rpc.sepolia.org"],
     },
   },
   blockExplorers: {
     etherscan: {
-      name: 'Etherscan',
-      url: 'https://sepolia.etherscan.io',
+      name: "Etherscan",
+      url: "https://sepolia.etherscan.io",
     },
     default: {
-      name: 'Etherscan',
-      url: 'https://sepolia.etherscan.io',
+      name: "Etherscan",
+      url: "https://sepolia.etherscan.io",
     },
   },
   contracts: {
     multicall3: {
-      address: '0xca11bde05977b3631167028862be2a173976ca11',
+      address: "0xca11bde05977b3631167028862be2a173976ca11",
       blockCreated: 6507670,
+    },
+    ensRegistry: { address: "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e" },
+    ensUniversalResolver: {
+      address: "0x21B000Fd62a880b2125A61e36a284BB757b76025",
+      blockCreated: 3914906,
     },
   },
   testnet: true,
-} as const satisfies Chain
+} as const satisfies Chain;


### PR DESCRIPTION
## Description

Adding the ENS Registry and ensUniversalResolver contracts for Sepolia so they can be supported by viem and wagmi out of the box.

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/references/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: schlabach.eth
