### PR TITLE
Fix public mumbai RPC

### DIFF
--- a/packages/chains/src/polygonMumbai.ts
+++ b/packages/chains/src/polygonMumbai.ts
@@ -15,10 +15,10 @@ export const polygonMumbai = {
       webSocket: ['wss://polygon-mumbai.infura.io/ws/v3'],
     },
     default: {
-      http: ['https://matic-mumbai.chainstacklabs.com'],
+      http: ['https://rpc-mumbai.matic.today'],
     },
     public: {
-      http: ['https://matic-mumbai.chainstacklabs.com'],
+      http: ['https://rpc-mumbai.matic.today'],
     },
   },
   blockExplorers: {


### PR DESCRIPTION
Chainstack have sunset their Mumbai RPC. Added latest public RPC from the [Polygon wiki](https://wiki.polygon.technology/docs/pos/reference/rpc-endpoints/).

## Description

Replaces deprecated Mumbai RPC and default

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/references/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: vijay.eth
